### PR TITLE
WIP nameof function

### DIFF
--- a/Bicep.sln.DotSettings
+++ b/Bicep.sln.DotSettings
@@ -2,8 +2,10 @@
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Etxt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=f9fce829_002De6f4_002D4cb2_002D80f1_002D5497c44f51df/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static" AccessRightKinds="Private" Description="Static fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Housekeeping/ProjectModelSynchronizer/ReadProjectModelFromDisk/@EntryValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Bicep.Core.IntegrationTests/Scenarios/NameofFunctionTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/NameofFunctionTests.cs
@@ -144,14 +144,14 @@ output name string = nameof(sqlServer::databases)
    name: 'storage123'
  }
 
- output name string = nameof(myStorage.{{resourceProperty}})
+ var name = nameof(myStorage.{{resourceProperty}})
 
  """);
 
             using (new AssertionScope())
             {
                 result.Should().NotHaveAnyCompilationBlockingDiagnostics();
-                result.Template.Should().HaveValueAtPath("$.outputs['name'].value", expectedValue);
+                result.Template.Should().HaveValueAtPath("$.variables['name']", expectedValue);
             }
         }
 

--- a/src/Bicep.Core.IntegrationTests/Scenarios/NameofFunctionTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/NameofFunctionTests.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.IntegrationTests.Scenarios
+{
+    [TestClass]
+    public class NameofFunctionTests
+    {
+        [TestMethod]
+        public void NameofFunction_OnObjectProperty_ReturnsPropertyName()
+        {
+            var result = CompilationHelper.Compile("""
+var obj = {
+  prop: 'value'
+}
+output name string = nameof(obj.prop)
+""");
+
+            using (new AssertionScope())
+            {
+                result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+                result.Template.Should().HaveValueAtPath("$.outputs['name'].value", "prop");
+            }
+        }
+
+        [TestMethod]
+        public void NameofFunction_OnVariable_ReturnsVariableName()
+        {
+            var result = CompilationHelper.Compile("""
+var obj = {
+  prop: 'value'
+}
+output name string = nameof(obj)
+""");
+
+            using (new AssertionScope())
+            {
+                result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+                result.Template.Should().HaveValueAtPath("$.outputs['name'].value", "obj");
+            }
+        }
+
+        [TestMethod]
+        public void NameofFunction_OnParameter_ReturnsParameterName()
+        {
+            var result = CompilationHelper.Compile("""
+                                                   param test string
+                                                   output name string = nameof(test)
+                                                   """);
+
+            using (new AssertionScope())
+            {
+                result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+                result.Template.Should().HaveValueAtPath("$.outputs['name'].value", "test");
+            }
+        }
+
+        [TestMethod]
+        public void NameofFunction_OnResource_ReturnsResourceSymbolicName()
+        {
+            var result = CompilationHelper.Compile("""
+resource myStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'storage123'
+}
+
+output name string = nameof(myStorage)
+""");
+
+            using (new AssertionScope())
+            {
+                result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+                result.Template.Should().HaveValueAtPath("$.outputs['name'].value", "myStorage");
+            }
+        }
+
+        [TestMethod]
+        public void NameofFunction_OnChildResource_ReturnsResourceSymbolicName()
+        {
+            var result = CompilationHelper.Compile("""
+resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-name'
+
+  resource primaryDb 'databases' = {
+    name: 'primary'
+  }
+}
+
+output name string = nameof(sqlServer::primaryDb)
+""");
+
+            using (new AssertionScope())
+            {
+                result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+                result.Template.Should().HaveValueAtPath("$.outputs['name'].value", "primaryDb");
+            }
+        }
+
+        [TestMethod]
+        public void NameofFunction_OnLoopedResource_ReturnsResourceSymbolicName()
+        {
+            var result = CompilationHelper.Compile("""
+
+var dbs = [
+  'primary'
+  'secondary'
+  'tertiary'
+]
+   
+resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-name'
+
+  @batchSize(1)
+  resource databases 'databases' = [for db in dbs: {
+    name: db
+  }]
+}
+
+output name string = nameof(sqlServer::databases)
+""");
+
+            using (new AssertionScope())
+            {
+                result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+                result.Template.Should().HaveValueAtPath("$.outputs['name'].value", "databases");
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("name", "name")]
+        [DataRow("type", "type")]
+        [DataRow("location", "location")]
+        [DataRow("properties", "properties")]
+        [DataRow("properties.sku", "sku")]
+        public void NameofFunction_OnResourceProperty_ReturnsResourcePropertyName(string resourceProperty, string expectedValue)
+        {
+            var result = CompilationHelper.Compile($$"""
+ resource myStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+   name: 'storage123'
+ }
+
+ output name string = nameof(myStorage.{{resourceProperty}})
+
+ """);
+
+            using (new AssertionScope())
+            {
+                result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+                result.Template.Should().HaveValueAtPath("$.outputs['name'].value", expectedValue);
+            }
+        }
+
+        [TestMethod]
+        public void UsingNameofFunction_ShouldNotGenerateDependsOnEntries()
+        {
+            var result = CompilationHelper.Compile("""
+resource myStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'storage123'
+}
+
+resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
+  name: nameof(myStorage)
+}
+""");
+
+            using (new AssertionScope())
+            {
+                result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+                result.Template.Should().HaveValueAtPath("$.resources[?(@.type == 'Microsoft.Sql/servers')].name", "myStorage", "Nameof function should emit static string during compilation");
+                result.Template.Should().NotHaveValueAtPath("$.resources[?(@.type == 'Microsoft.Sql/servers')].dependsOn", "Depends on should not be generated for nameof function usage");
+            }
+        }
+    }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
@@ -1130,11 +1130,11 @@
   },
   {
     "name": "nameof",
-    "description": "Returns the name of the specified parameter, variable, or resource.",
+    "description": "Returns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.",
     "fixedParameters": [
       {
         "name": "symbol",
-        "description": "The parameter, variable, or resource to retrieve the name of.",
+        "description": "The variable, resource, module or property to produce the name.",
         "type": "any",
         "required": true
       }

--- a/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
@@ -1129,6 +1129,25 @@
     ]
   },
   {
+    "name": "nameof",
+    "description": "Returns the name of the specified parameter, variable, or resource.",
+    "fixedParameters": [
+      {
+        "name": "symbol",
+        "description": "The parameter, variable, or resource to retrieve the name of.",
+        "type": "any",
+        "required": true
+      }
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(symbol: any): string",
+    "parameterTypeSignatures": [
+      "symbol: any"
+    ]
+  },
+  {
     "name": "newGuid",
     "description": "Returns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.",
     "fixedParameters": [],

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -1873,6 +1873,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "ne",
     "kind": "variable",
     "detail": "ne",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -1873,11 +1873,95 @@
     }
   },
   {
+    "label": "nameOfConstant",
+    "kind": "variable",
+    "detail": "nameOfConstant",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameOfConstant",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameOfConstant"
+    }
+  },
+  {
+    "label": "nameOfKeyword1",
+    "kind": "variable",
+    "detail": "nameOfKeyword1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameOfKeyword1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameOfKeyword1"
+    }
+  },
+  {
+    "label": "nameOfKeyword2",
+    "kind": "variable",
+    "detail": "nameOfKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameOfKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameOfKeyword2"
+    }
+  },
+  {
+    "label": "nameOfKeyword3",
+    "kind": "variable",
+    "detail": "nameOfKeyword3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameOfKeyword3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameOfKeyword3"
+    }
+  },
+  {
+    "label": "nameOfKeyword4",
+    "kind": "variable",
+    "detail": "nameOfKeyword4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameOfKeyword4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameOfKeyword4"
+    }
+  },
+  {
+    "label": "nameOfKeyword5",
+    "kind": "variable",
+    "detail": "nameOfKeyword5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameOfKeyword5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameOfKeyword5"
+    }
+  },
+  {
     "label": "nameof",
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1891,6 +1975,76 @@
     "command": {
       "title": "signature help",
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "nameofEmpty",
+    "kind": "variable",
+    "detail": "nameofEmpty",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameofEmpty",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameofEmpty"
+    }
+  },
+  {
+    "label": "nameofExpression1",
+    "kind": "variable",
+    "detail": "nameofExpression1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameofExpression1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameofExpression1"
+    }
+  },
+  {
+    "label": "nameofExpression2",
+    "kind": "variable",
+    "detail": "nameofExpression2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameofExpression2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameofExpression2"
+    }
+  },
+  {
+    "label": "nameofUnknown",
+    "kind": "variable",
+    "detail": "nameofUnknown",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameofUnknown",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameofUnknown"
+    }
+  },
+  {
+    "label": "nameofVar",
+    "kind": "variable",
+    "detail": "nameofVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameofVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameofVar"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
@@ -903,6 +903,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "newGuid",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
@@ -907,7 +907,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.bicep
@@ -1,4 +1,4 @@
-﻿/*
+/*
   This tests the various cases of invalid expressions.
 */
 
@@ -248,6 +248,19 @@ var partialObject = {
   d  : %
 }
 
+//nameof expressions
+var nameOfConstant = nameof('abc')
+var nameOfKeyword1 = nameof(param)
+var nameOfKeyword2 = nameof(var)
+var nameOfKeyword3 = nameof(resource)
+var nameOfKeyword4 = nameof(module)
+var nameOfKeyword5 = nameof(output)
+var nameofExpression1 = nameof(1 + 2)
+var nameofVar= 'abc'
+var nameofExpression2 = nameof(true ? nameofVar : nameofVar)
+var nameofUnknown = nameof(symbolNotFound)
+var nameofEmpty = nameof()
+
 // dangling decorators - to make sure the tests work, please do not add contents after this line
 @concat()
 @sys.secure()
@@ -263,6 +276,4 @@ var unterminated2 = (,
 
 // trailing decorator with no declaration
 @minLength()
-
-
 

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.diagnostics.bicep
@@ -585,6 +585,39 @@ var partialObject = {
 //@[07:08) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (CodeDescription: none) |%|
 }
 
+//nameof expressions
+var nameOfConstant = nameof('abc')
+//@[04:18) [no-unused-vars (Warning)] Variable "nameOfConstant" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameOfConstant|
+//@[28:33) [BCP407 (Error)] Expression does not have a name (CodeDescription: none) |'abc'|
+var nameOfKeyword1 = nameof(param)
+//@[04:18) [no-unused-vars (Warning)] Variable "nameOfKeyword1" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameOfKeyword1|
+//@[28:33) [BCP057 (Error)] The name "param" does not exist in the current context. (CodeDescription: none) |param|
+var nameOfKeyword2 = nameof(var)
+//@[04:18) [no-unused-vars (Warning)] Variable "nameOfKeyword2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameOfKeyword2|
+//@[28:31) [BCP057 (Error)] The name "var" does not exist in the current context. (CodeDescription: none) |var|
+var nameOfKeyword3 = nameof(resource)
+//@[04:18) [no-unused-vars (Warning)] Variable "nameOfKeyword3" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameOfKeyword3|
+//@[28:36) [BCP057 (Error)] The name "resource" does not exist in the current context. (CodeDescription: none) |resource|
+var nameOfKeyword4 = nameof(module)
+//@[04:18) [no-unused-vars (Warning)] Variable "nameOfKeyword4" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameOfKeyword4|
+//@[28:34) [BCP057 (Error)] The name "module" does not exist in the current context. (CodeDescription: none) |module|
+var nameOfKeyword5 = nameof(output)
+//@[04:18) [no-unused-vars (Warning)] Variable "nameOfKeyword5" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameOfKeyword5|
+//@[28:34) [BCP057 (Error)] The name "output" does not exist in the current context. (CodeDescription: none) |output|
+var nameofExpression1 = nameof(1 + 2)
+//@[04:21) [no-unused-vars (Warning)] Variable "nameofExpression1" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameofExpression1|
+//@[31:36) [BCP407 (Error)] Expression does not have a name (CodeDescription: none) |1 + 2|
+var nameofVar= 'abc'
+var nameofExpression2 = nameof(true ? nameofVar : nameofVar)
+//@[04:21) [no-unused-vars (Warning)] Variable "nameofExpression2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameofExpression2|
+//@[31:59) [BCP407 (Error)] Expression does not have a name (CodeDescription: none) |true ? nameofVar : nameofVar|
+var nameofUnknown = nameof(symbolNotFound)
+//@[04:17) [no-unused-vars (Warning)] Variable "nameofUnknown" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameofUnknown|
+//@[27:41) [BCP057 (Error)] The name "symbolNotFound" does not exist in the current context. (CodeDescription: none) |symbolNotFound|
+var nameofEmpty = nameof()
+//@[04:15) [no-unused-vars (Warning)] Variable "nameofEmpty" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameofEmpty|
+//@[24:26) [BCP071 (Error)] Expected 1 argument, but got 0. (CodeDescription: none) |()|
+
 // dangling decorators - to make sure the tests work, please do not add contents after this line
 @concat()
 //@[01:07) [BCP152 (Error)] Function "concat" cannot be used as a decorator. (CodeDescription: none) |concat|
@@ -617,7 +650,5 @@ var unterminated2 = (,
 @minLength()
 //@[00:12) [BCP292 (Error)] Expected a parameter, output, or type declaration after the decorator. (CodeDescription: none) |@minLength()|
 //@[10:12) [BCP071 (Error)] Expected 1 argument, but got 0. (CodeDescription: none) |()|
-
-
 
 

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.formatted.bicep
@@ -238,6 +238,19 @@ var partialObject = {
   d  : %
 }
 
+//nameof expressions
+var nameOfConstant = nameof('abc')
+var nameOfKeyword1 = nameof(param)
+var nameOfKeyword2 = nameof(var)
+var nameOfKeyword3 = nameof(resource)
+var nameOfKeyword4 = nameof(module)
+var nameOfKeyword5 = nameof(output)
+var nameofExpression1 = nameof(1 + 2)
+var nameofVar = 'abc'
+var nameofExpression2 = nameof(true ? nameofVar : nameofVar)
+var nameofUnknown = nameof(symbolNotFound)
+var nameofEmpty = nameof()
+
 // dangling decorators - to make sure the tests work, please do not add contents after this line
 @concat()
 @sys.secure()

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.symbols.bicep
@@ -365,6 +365,30 @@ var partialObject = {
   d  : %
 }
 
+//nameof expressions
+var nameOfConstant = nameof('abc')
+//@[4:18) Variable nameOfConstant. Type: error. Declaration start char: 0, length: 34
+var nameOfKeyword1 = nameof(param)
+//@[4:18) Variable nameOfKeyword1. Type: error. Declaration start char: 0, length: 34
+var nameOfKeyword2 = nameof(var)
+//@[4:18) Variable nameOfKeyword2. Type: error. Declaration start char: 0, length: 32
+var nameOfKeyword3 = nameof(resource)
+//@[4:18) Variable nameOfKeyword3. Type: error. Declaration start char: 0, length: 37
+var nameOfKeyword4 = nameof(module)
+//@[4:18) Variable nameOfKeyword4. Type: error. Declaration start char: 0, length: 35
+var nameOfKeyword5 = nameof(output)
+//@[4:18) Variable nameOfKeyword5. Type: error. Declaration start char: 0, length: 35
+var nameofExpression1 = nameof(1 + 2)
+//@[4:21) Variable nameofExpression1. Type: error. Declaration start char: 0, length: 37
+var nameofVar= 'abc'
+//@[4:13) Variable nameofVar. Type: 'abc'. Declaration start char: 0, length: 20
+var nameofExpression2 = nameof(true ? nameofVar : nameofVar)
+//@[4:21) Variable nameofExpression2. Type: error. Declaration start char: 0, length: 60
+var nameofUnknown = nameof(symbolNotFound)
+//@[4:17) Variable nameofUnknown. Type: error. Declaration start char: 0, length: 42
+var nameofEmpty = nameof()
+//@[4:15) Variable nameofEmpty. Type: error. Declaration start char: 0, length: 26
+
 // dangling decorators - to make sure the tests work, please do not add contents after this line
 @concat()
 @sys.secure()
@@ -385,7 +409,5 @@ var unterminated2 = (,
 
 // trailing decorator with no declaration
 @minLength()
-
-
 
 

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 /*
-//@[00:5984) ProgramSyntax
+//@[00:6407) ProgramSyntax
   This tests the various cases of invalid expressions.
 */
 //@[02:0004) ├─Token(NewLine) |\n\n|
@@ -2549,6 +2549,184 @@ var partialObject = {
 //@[00:0001) |   └─Token(RightBrace) |}|
 //@[01:0003) ├─Token(NewLine) |\n\n|
 
+//nameof expressions
+//@[20:0021) ├─Token(NewLine) |\n|
+var nameOfConstant = nameof('abc')
+//@[00:0034) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0018) | ├─IdentifierSyntax
+//@[04:0018) | | └─Token(Identifier) |nameOfConstant|
+//@[19:0020) | ├─Token(Assignment) |=|
+//@[21:0034) | └─FunctionCallSyntax
+//@[21:0027) |   ├─IdentifierSyntax
+//@[21:0027) |   | └─Token(Identifier) |nameof|
+//@[27:0028) |   ├─Token(LeftParen) |(|
+//@[28:0033) |   ├─FunctionArgumentSyntax
+//@[28:0033) |   | └─StringSyntax
+//@[28:0033) |   |   └─Token(StringComplete) |'abc'|
+//@[33:0034) |   └─Token(RightParen) |)|
+//@[34:0035) ├─Token(NewLine) |\n|
+var nameOfKeyword1 = nameof(param)
+//@[00:0034) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0018) | ├─IdentifierSyntax
+//@[04:0018) | | └─Token(Identifier) |nameOfKeyword1|
+//@[19:0020) | ├─Token(Assignment) |=|
+//@[21:0034) | └─FunctionCallSyntax
+//@[21:0027) |   ├─IdentifierSyntax
+//@[21:0027) |   | └─Token(Identifier) |nameof|
+//@[27:0028) |   ├─Token(LeftParen) |(|
+//@[28:0033) |   ├─FunctionArgumentSyntax
+//@[28:0033) |   | └─VariableAccessSyntax
+//@[28:0033) |   |   └─IdentifierSyntax
+//@[28:0033) |   |     └─Token(Identifier) |param|
+//@[33:0034) |   └─Token(RightParen) |)|
+//@[34:0035) ├─Token(NewLine) |\n|
+var nameOfKeyword2 = nameof(var)
+//@[00:0032) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0018) | ├─IdentifierSyntax
+//@[04:0018) | | └─Token(Identifier) |nameOfKeyword2|
+//@[19:0020) | ├─Token(Assignment) |=|
+//@[21:0032) | └─FunctionCallSyntax
+//@[21:0027) |   ├─IdentifierSyntax
+//@[21:0027) |   | └─Token(Identifier) |nameof|
+//@[27:0028) |   ├─Token(LeftParen) |(|
+//@[28:0031) |   ├─FunctionArgumentSyntax
+//@[28:0031) |   | └─VariableAccessSyntax
+//@[28:0031) |   |   └─IdentifierSyntax
+//@[28:0031) |   |     └─Token(Identifier) |var|
+//@[31:0032) |   └─Token(RightParen) |)|
+//@[32:0033) ├─Token(NewLine) |\n|
+var nameOfKeyword3 = nameof(resource)
+//@[00:0037) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0018) | ├─IdentifierSyntax
+//@[04:0018) | | └─Token(Identifier) |nameOfKeyword3|
+//@[19:0020) | ├─Token(Assignment) |=|
+//@[21:0037) | └─FunctionCallSyntax
+//@[21:0027) |   ├─IdentifierSyntax
+//@[21:0027) |   | └─Token(Identifier) |nameof|
+//@[27:0028) |   ├─Token(LeftParen) |(|
+//@[28:0036) |   ├─FunctionArgumentSyntax
+//@[28:0036) |   | └─VariableAccessSyntax
+//@[28:0036) |   |   └─IdentifierSyntax
+//@[28:0036) |   |     └─Token(Identifier) |resource|
+//@[36:0037) |   └─Token(RightParen) |)|
+//@[37:0038) ├─Token(NewLine) |\n|
+var nameOfKeyword4 = nameof(module)
+//@[00:0035) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0018) | ├─IdentifierSyntax
+//@[04:0018) | | └─Token(Identifier) |nameOfKeyword4|
+//@[19:0020) | ├─Token(Assignment) |=|
+//@[21:0035) | └─FunctionCallSyntax
+//@[21:0027) |   ├─IdentifierSyntax
+//@[21:0027) |   | └─Token(Identifier) |nameof|
+//@[27:0028) |   ├─Token(LeftParen) |(|
+//@[28:0034) |   ├─FunctionArgumentSyntax
+//@[28:0034) |   | └─VariableAccessSyntax
+//@[28:0034) |   |   └─IdentifierSyntax
+//@[28:0034) |   |     └─Token(Identifier) |module|
+//@[34:0035) |   └─Token(RightParen) |)|
+//@[35:0036) ├─Token(NewLine) |\n|
+var nameOfKeyword5 = nameof(output)
+//@[00:0035) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0018) | ├─IdentifierSyntax
+//@[04:0018) | | └─Token(Identifier) |nameOfKeyword5|
+//@[19:0020) | ├─Token(Assignment) |=|
+//@[21:0035) | └─FunctionCallSyntax
+//@[21:0027) |   ├─IdentifierSyntax
+//@[21:0027) |   | └─Token(Identifier) |nameof|
+//@[27:0028) |   ├─Token(LeftParen) |(|
+//@[28:0034) |   ├─FunctionArgumentSyntax
+//@[28:0034) |   | └─VariableAccessSyntax
+//@[28:0034) |   |   └─IdentifierSyntax
+//@[28:0034) |   |     └─Token(Identifier) |output|
+//@[34:0035) |   └─Token(RightParen) |)|
+//@[35:0036) ├─Token(NewLine) |\n|
+var nameofExpression1 = nameof(1 + 2)
+//@[00:0037) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0021) | ├─IdentifierSyntax
+//@[04:0021) | | └─Token(Identifier) |nameofExpression1|
+//@[22:0023) | ├─Token(Assignment) |=|
+//@[24:0037) | └─FunctionCallSyntax
+//@[24:0030) |   ├─IdentifierSyntax
+//@[24:0030) |   | └─Token(Identifier) |nameof|
+//@[30:0031) |   ├─Token(LeftParen) |(|
+//@[31:0036) |   ├─FunctionArgumentSyntax
+//@[31:0036) |   | └─BinaryOperationSyntax
+//@[31:0032) |   |   ├─IntegerLiteralSyntax
+//@[31:0032) |   |   | └─Token(Integer) |1|
+//@[33:0034) |   |   ├─Token(Plus) |+|
+//@[35:0036) |   |   └─IntegerLiteralSyntax
+//@[35:0036) |   |     └─Token(Integer) |2|
+//@[36:0037) |   └─Token(RightParen) |)|
+//@[37:0038) ├─Token(NewLine) |\n|
+var nameofVar= 'abc'
+//@[00:0020) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0013) | ├─IdentifierSyntax
+//@[04:0013) | | └─Token(Identifier) |nameofVar|
+//@[13:0014) | ├─Token(Assignment) |=|
+//@[15:0020) | └─StringSyntax
+//@[15:0020) |   └─Token(StringComplete) |'abc'|
+//@[20:0021) ├─Token(NewLine) |\n|
+var nameofExpression2 = nameof(true ? nameofVar : nameofVar)
+//@[00:0060) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0021) | ├─IdentifierSyntax
+//@[04:0021) | | └─Token(Identifier) |nameofExpression2|
+//@[22:0023) | ├─Token(Assignment) |=|
+//@[24:0060) | └─FunctionCallSyntax
+//@[24:0030) |   ├─IdentifierSyntax
+//@[24:0030) |   | └─Token(Identifier) |nameof|
+//@[30:0031) |   ├─Token(LeftParen) |(|
+//@[31:0059) |   ├─FunctionArgumentSyntax
+//@[31:0059) |   | └─TernaryOperationSyntax
+//@[31:0035) |   |   ├─BooleanLiteralSyntax
+//@[31:0035) |   |   | └─Token(TrueKeyword) |true|
+//@[36:0037) |   |   ├─Token(Question) |?|
+//@[38:0047) |   |   ├─VariableAccessSyntax
+//@[38:0047) |   |   | └─IdentifierSyntax
+//@[38:0047) |   |   |   └─Token(Identifier) |nameofVar|
+//@[48:0049) |   |   ├─Token(Colon) |:|
+//@[50:0059) |   |   └─VariableAccessSyntax
+//@[50:0059) |   |     └─IdentifierSyntax
+//@[50:0059) |   |       └─Token(Identifier) |nameofVar|
+//@[59:0060) |   └─Token(RightParen) |)|
+//@[60:0061) ├─Token(NewLine) |\n|
+var nameofUnknown = nameof(symbolNotFound)
+//@[00:0042) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0017) | ├─IdentifierSyntax
+//@[04:0017) | | └─Token(Identifier) |nameofUnknown|
+//@[18:0019) | ├─Token(Assignment) |=|
+//@[20:0042) | └─FunctionCallSyntax
+//@[20:0026) |   ├─IdentifierSyntax
+//@[20:0026) |   | └─Token(Identifier) |nameof|
+//@[26:0027) |   ├─Token(LeftParen) |(|
+//@[27:0041) |   ├─FunctionArgumentSyntax
+//@[27:0041) |   | └─VariableAccessSyntax
+//@[27:0041) |   |   └─IdentifierSyntax
+//@[27:0041) |   |     └─Token(Identifier) |symbolNotFound|
+//@[41:0042) |   └─Token(RightParen) |)|
+//@[42:0043) ├─Token(NewLine) |\n|
+var nameofEmpty = nameof()
+//@[00:0026) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0015) | ├─IdentifierSyntax
+//@[04:0015) | | └─Token(Identifier) |nameofEmpty|
+//@[16:0017) | ├─Token(Assignment) |=|
+//@[18:0026) | └─FunctionCallSyntax
+//@[18:0024) |   ├─IdentifierSyntax
+//@[18:0024) |   | └─Token(Identifier) |nameof|
+//@[24:0025) |   ├─Token(LeftParen) |(|
+//@[25:0026) |   └─Token(RightParen) |)|
+//@[26:0028) ├─Token(NewLine) |\n\n|
+
 // dangling decorators - to make sure the tests work, please do not add contents after this line
 //@[96:0097) ├─Token(NewLine) |\n|
 @concat()
@@ -2663,7 +2841,7 @@ var unterminated2 = (,
 // trailing decorator with no declaration
 //@[41:0042) ├─Token(NewLine) |\n|
 @minLength()
-//@[00:0016) ├─MissingDeclarationSyntax
+//@[00:0014) ├─MissingDeclarationSyntax
 //@[00:0012) | ├─DecoratorSyntax
 //@[00:0001) | | ├─Token(At) |@|
 //@[01:0012) | | └─FunctionCallSyntax
@@ -2671,9 +2849,7 @@ var unterminated2 = (,
 //@[01:0010) | |   | └─Token(Identifier) |minLength|
 //@[10:0011) | |   ├─Token(LeftParen) |(|
 //@[11:0012) | |   └─Token(RightParen) |)|
-//@[12:0016) | └─Token(NewLine) |\n\n\n\n|
-
-
+//@[12:0014) | └─Token(NewLine) |\n\n|
 
 
 //@[00:0000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.tokens.bicep
@@ -1568,6 +1568,110 @@ var partialObject = {
 //@[00:01) RightBrace |}|
 //@[01:03) NewLine |\n\n|
 
+//nameof expressions
+//@[20:21) NewLine |\n|
+var nameOfConstant = nameof('abc')
+//@[00:03) Identifier |var|
+//@[04:18) Identifier |nameOfConstant|
+//@[19:20) Assignment |=|
+//@[21:27) Identifier |nameof|
+//@[27:28) LeftParen |(|
+//@[28:33) StringComplete |'abc'|
+//@[33:34) RightParen |)|
+//@[34:35) NewLine |\n|
+var nameOfKeyword1 = nameof(param)
+//@[00:03) Identifier |var|
+//@[04:18) Identifier |nameOfKeyword1|
+//@[19:20) Assignment |=|
+//@[21:27) Identifier |nameof|
+//@[27:28) LeftParen |(|
+//@[28:33) Identifier |param|
+//@[33:34) RightParen |)|
+//@[34:35) NewLine |\n|
+var nameOfKeyword2 = nameof(var)
+//@[00:03) Identifier |var|
+//@[04:18) Identifier |nameOfKeyword2|
+//@[19:20) Assignment |=|
+//@[21:27) Identifier |nameof|
+//@[27:28) LeftParen |(|
+//@[28:31) Identifier |var|
+//@[31:32) RightParen |)|
+//@[32:33) NewLine |\n|
+var nameOfKeyword3 = nameof(resource)
+//@[00:03) Identifier |var|
+//@[04:18) Identifier |nameOfKeyword3|
+//@[19:20) Assignment |=|
+//@[21:27) Identifier |nameof|
+//@[27:28) LeftParen |(|
+//@[28:36) Identifier |resource|
+//@[36:37) RightParen |)|
+//@[37:38) NewLine |\n|
+var nameOfKeyword4 = nameof(module)
+//@[00:03) Identifier |var|
+//@[04:18) Identifier |nameOfKeyword4|
+//@[19:20) Assignment |=|
+//@[21:27) Identifier |nameof|
+//@[27:28) LeftParen |(|
+//@[28:34) Identifier |module|
+//@[34:35) RightParen |)|
+//@[35:36) NewLine |\n|
+var nameOfKeyword5 = nameof(output)
+//@[00:03) Identifier |var|
+//@[04:18) Identifier |nameOfKeyword5|
+//@[19:20) Assignment |=|
+//@[21:27) Identifier |nameof|
+//@[27:28) LeftParen |(|
+//@[28:34) Identifier |output|
+//@[34:35) RightParen |)|
+//@[35:36) NewLine |\n|
+var nameofExpression1 = nameof(1 + 2)
+//@[00:03) Identifier |var|
+//@[04:21) Identifier |nameofExpression1|
+//@[22:23) Assignment |=|
+//@[24:30) Identifier |nameof|
+//@[30:31) LeftParen |(|
+//@[31:32) Integer |1|
+//@[33:34) Plus |+|
+//@[35:36) Integer |2|
+//@[36:37) RightParen |)|
+//@[37:38) NewLine |\n|
+var nameofVar= 'abc'
+//@[00:03) Identifier |var|
+//@[04:13) Identifier |nameofVar|
+//@[13:14) Assignment |=|
+//@[15:20) StringComplete |'abc'|
+//@[20:21) NewLine |\n|
+var nameofExpression2 = nameof(true ? nameofVar : nameofVar)
+//@[00:03) Identifier |var|
+//@[04:21) Identifier |nameofExpression2|
+//@[22:23) Assignment |=|
+//@[24:30) Identifier |nameof|
+//@[30:31) LeftParen |(|
+//@[31:35) TrueKeyword |true|
+//@[36:37) Question |?|
+//@[38:47) Identifier |nameofVar|
+//@[48:49) Colon |:|
+//@[50:59) Identifier |nameofVar|
+//@[59:60) RightParen |)|
+//@[60:61) NewLine |\n|
+var nameofUnknown = nameof(symbolNotFound)
+//@[00:03) Identifier |var|
+//@[04:17) Identifier |nameofUnknown|
+//@[18:19) Assignment |=|
+//@[20:26) Identifier |nameof|
+//@[26:27) LeftParen |(|
+//@[27:41) Identifier |symbolNotFound|
+//@[41:42) RightParen |)|
+//@[42:43) NewLine |\n|
+var nameofEmpty = nameof()
+//@[00:03) Identifier |var|
+//@[04:15) Identifier |nameofEmpty|
+//@[16:17) Assignment |=|
+//@[18:24) Identifier |nameof|
+//@[24:25) LeftParen |(|
+//@[25:26) RightParen |)|
+//@[26:28) NewLine |\n\n|
+
 // dangling decorators - to make sure the tests work, please do not add contents after this line
 //@[96:97) NewLine |\n|
 @concat()
@@ -1647,9 +1751,7 @@ var unterminated2 = (,
 //@[01:10) Identifier |minLength|
 //@[10:11) LeftParen |(|
 //@[11:12) RightParen |)|
-//@[12:16) NewLine |\n\n\n\n|
-
-
+//@[12:14) NewLine |\n\n|
 
 
 //@[00:00) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -2246,6 +2246,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nonExistentFileRef",
     "kind": "module",
     "detail": "nonExistentFileRef",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -2250,7 +2250,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -2246,6 +2246,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nonExistentFileRef",
     "kind": "module",
     "detail": "nonExistentFileRef",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -2250,7 +2250,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -1050,6 +1050,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "objectKeys",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -1054,7 +1054,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -1014,6 +1014,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "objectKeys",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -1018,7 +1018,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -1000,6 +1000,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "objectKeys",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -1004,7 +1004,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -1000,6 +1000,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "objectKeys",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -1004,7 +1004,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -1487,6 +1487,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "newGuid",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -1491,7 +1491,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -1487,6 +1487,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "newGuid",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -1491,7 +1491,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -1473,6 +1473,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "newGuid",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -1477,7 +1477,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -1495,7 +1495,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -1491,6 +1491,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "newGuid",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -3584,6 +3584,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -3588,7 +3588,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -3548,6 +3548,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -3552,7 +3552,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -3576,6 +3576,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -3580,7 +3580,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -3807,6 +3807,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -3811,7 +3811,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -3807,6 +3807,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -3811,7 +3811,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -3807,6 +3807,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -3811,7 +3811,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -3807,6 +3807,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -3811,7 +3811,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -3569,6 +3569,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -3573,7 +3573,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -3569,6 +3569,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -3573,7 +3573,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -3569,6 +3569,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -3573,7 +3573,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -3569,6 +3569,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -3573,7 +3573,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -4059,7 +4059,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -4055,6 +4055,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -4059,7 +4059,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -4055,6 +4055,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -4059,7 +4059,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -4055,6 +4055,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -4059,7 +4059,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -4055,6 +4055,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -3566,7 +3566,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -3562,6 +3562,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -3566,7 +3566,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -3562,6 +3562,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -3566,7 +3566,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -3562,6 +3562,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -3566,7 +3566,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -3562,6 +3562,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -3559,7 +3559,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -3555,6 +3555,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -3559,7 +3559,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -3555,6 +3555,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -3559,7 +3559,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -3555,6 +3555,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -3559,7 +3559,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -3555,6 +3555,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -3538,7 +3538,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -3534,6 +3534,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -3538,7 +3538,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -3534,6 +3534,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -3677,6 +3677,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -3681,7 +3681,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -3551,6 +3551,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -3555,7 +3555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -3565,6 +3565,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -3569,7 +3569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -3565,6 +3565,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -3569,7 +3569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -3565,6 +3565,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -3569,7 +3569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -3619,7 +3619,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -3615,6 +3615,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -3583,7 +3583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -3579,6 +3579,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -3565,6 +3565,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -3569,7 +3569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -1536,7 +1536,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -1532,6 +1532,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -1554,6 +1554,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -1558,7 +1558,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -1550,6 +1550,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -1554,7 +1554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.bicep
@@ -1,4 +1,4 @@
-﻿
+
 @sys.description('this is deployTimeSuffix param')
 param deployTimeSuffix string = newGuid()
 
@@ -369,3 +369,8 @@ module withSpace 'module with space.bicep' = {
 module folderWithSpace 'child/folder with space/child with space.bicep' = {
   name: 'childWithSpace'
 }
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.bicep
@@ -374,3 +374,8 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 
 var nameofModule = nameof(folderWithSpace)
 var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+
+module moduleWithNameof 'modulea.bicep' = {
+  name: 'nameofModule'
+  scope: resourceGroup(nameof(nameofModuleParam))
+}

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.diagnostics.bicep
@@ -381,3 +381,8 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
   name: 'childWithSpace'
 }
 
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.formatted.bicep
@@ -389,3 +389,8 @@ module withSpace 'module with space.bicep' = {
 module folderWithSpace 'child/folder with space/child with space.bicep' = {
   name: 'childWithSpace'
 }
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.ir.bicep
@@ -1,5 +1,5 @@
 
-//@[000:8922) ProgramExpression
+//@[000:9059) ProgramExpression
 //@[000:0000) | ├─ResourceDependencyExpression [UNPARENTED]
 //@[000:0000) | | └─ModuleReferenceExpression [UNPARENTED]
 //@[000:0000) | ├─ResourceDependencyExpression [UNPARENTED]
@@ -1252,4 +1252,9 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@[002:0006) |     ├─StringLiteralExpression { Value = name }
 //@[008:0024) |     └─StringLiteralExpression { Value = childWithSpace }
 }
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
 

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5913067076123852117"
+      "templateHash": "1954512251654163120"
     }
   },
   "parameters": {
@@ -53,7 +53,9 @@
         "name": "secret02",
         "version": "versionB"
       }
-    ]
+    ],
+    "nameofModule": "folderWithSpace",
+    "nameofModuleParam": "exposedSecureString"
   },
   "resources": [
     {

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.sourcemap.bicep
@@ -2189,7 +2189,7 @@ var vaults = [
 ]
 var secrets = [
 //@    "secrets": [
-//@    ]
+//@    ],
   {
 //@      {
 //@      },

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.sourcemap.bicep
@@ -2412,3 +2412,8 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@      "name": "childWithSpace",
 }
 
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "847860570633955362"
+      "templateHash": "10571611031141977059"
     }
   },
   "parameters": {
@@ -54,7 +54,9 @@
         "name": "secret02",
         "version": "versionB"
       }
-    ]
+    ],
+    "nameofModule": "folderWithSpace",
+    "nameofModuleParam": "exposedSecureString"
   },
   "resources": {
     "resWithDependencies": {

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.symbols.bicep
@@ -449,3 +449,8 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
   name: 'childWithSpace'
 }
 
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[000:8922) ProgramSyntax
+//@[000:9059) ProgramSyntax
 //@[000:0002) ├─Token(NewLine) |\r\n|
 @sys.description('this is deployTimeSuffix param')
 //@[000:0093) ├─ParameterDeclarationSyntax
@@ -3351,6 +3351,10 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@[024:0026) |   ├─Token(NewLine) |\r\n|
 }
 //@[000:0001) |   └─Token(RightBrace) |}|
-//@[001:0003) ├─Token(NewLine) |\r\n|
+//@[001:0004) ├─Token(NewLine) |\r\n\n|
 
-//@[000:0000) └─Token(EndOfFile) ||
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.tokens.bicep
@@ -2102,6 +2102,10 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@[024:026) NewLine |\r\n|
 }
 //@[000:001) RightBrace |}|
-//@[001:003) NewLine |\r\n|
+//@[001:004) NewLine |\r\n\n|
 
-//@[000:000) EndOfFile ||
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.bicep
@@ -210,4 +210,4 @@ param decoratedArray array = [
     newGuid()
 ]
 
-param nameof string = nameof(decoratedArray)
+param nameofParam string = nameof(decoratedArray)

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.bicep
@@ -1,4 +1,4 @@
-﻿/*
+/*
   This is a block comment.
 */
 
@@ -209,3 +209,5 @@ param decoratedArray array = [
     utcNow()
     newGuid()
 ]
+
+param nameof string = nameof(decoratedArray)

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.diagnostics.bicep
@@ -239,8 +239,10 @@ param decoratedObject object = {
 @sys.maxLength(20)
 @sys.description('An array.')
 param decoratedArray array = [
-//@[06:020) [no-unused-params (Warning)] Parameter "decoratedArray" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |decoratedArray|
     utcNow()
     newGuid()
 ]
+
+param nameofParam string = nameof(decoratedArray)
+//@[06:017) [no-unused-params (Warning)] Parameter "nameofParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |nameofParam|
 

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.formatted.bicep
@@ -207,3 +207,5 @@ param decoratedArray array = [
   utcNow()
   newGuid()
 ]
+
+param nameofParam string = nameof(decoratedArray)

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.ir.bicep
@@ -1,5 +1,5 @@
 /*
-//@[000:3162) ProgramExpression
+//@[000:3213) ProgramExpression
   This is a block comment.
 */
 
@@ -418,23 +418,28 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-//@[000:0166) └─DeclaredParameterExpression { Name = decoratedArray }
-//@[014:0056)   ├─ObjectExpression
+//@[000:0166) ├─DeclaredParameterExpression { Name = decoratedArray }
+//@[014:0056) | ├─ObjectExpression
     description: 'I will be overrode.'
-//@[004:0038)   | └─ObjectPropertyExpression
-//@[004:0015)   |   ├─StringLiteralExpression { Value = description }
-//@[017:0038)   |   └─StringLiteralExpression { Value = I will be overrode. }
+//@[004:0038) | | └─ObjectPropertyExpression
+//@[004:0015) | |   ├─StringLiteralExpression { Value = description }
+//@[017:0038) | |   └─StringLiteralExpression { Value = I will be overrode. }
 })
 @sys.maxLength(20)
-//@[015:0017)   ├─IntegerLiteralExpression { Value = 20 }
+//@[015:0017) | ├─IntegerLiteralExpression { Value = 20 }
 @sys.description('An array.')
-//@[017:0028)   ├─StringLiteralExpression { Value = An array. }
+//@[017:0028) | ├─StringLiteralExpression { Value = An array. }
 param decoratedArray array = [
-//@[021:0026)   ├─AmbientTypeReferenceExpression { Name = array }
-//@[029:0059)   └─ArrayExpression
+//@[021:0026) | ├─AmbientTypeReferenceExpression { Name = array }
+//@[029:0059) | └─ArrayExpression
     utcNow()
-//@[004:0012)     ├─FunctionCallExpression { Name = utcNow }
+//@[004:0012) |   ├─FunctionCallExpression { Name = utcNow }
     newGuid()
-//@[004:0013)     └─FunctionCallExpression { Name = newGuid }
+//@[004:0013) |   └─FunctionCallExpression { Name = newGuid }
 ]
+
+param nameofParam string = nameof(decoratedArray)
+//@[000:0049) └─DeclaredParameterExpression { Name = nameofParam }
+//@[018:0024)   ├─AmbientTypeReferenceExpression { Name = string }
+//@[034:0048)   └─StringLiteralExpression { Value = decoratedArray }
 

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11554370276860411233"
+      "templateHash": "4645020002980758832"
     }
   },
   "parameters": {
@@ -103,13 +103,13 @@
     },
     "storageName": {
       "type": "string",
-      "maxLength": 24,
-      "minLength": 3
+      "minLength": 3,
+      "maxLength": 24
     },
     "someArray": {
       "type": "array",
-      "maxLength": 24,
-      "minLength": 3
+      "minLength": 3,
+      "maxLength": 24
     },
     "emptyMetadata": {
       "type": "string",
@@ -149,8 +149,8 @@
       "metadata": {
         "description": "Name of the storage account"
       },
-      "maxLength": 24,
-      "minLength": 3
+      "minLength": 3,
+      "maxLength": 24
     },
     "defaultExpression": {
       "type": "bool",
@@ -178,8 +178,8 @@
         "Apple",
         "Banana"
       ],
-      "maxLength": 10,
-      "minLength": 2
+      "minLength": 2,
+      "maxLength": 10
     },
     "decoratedInt": {
       "type": "int",
@@ -188,8 +188,8 @@
     },
     "negativeValues": {
       "type": "int",
-      "maxValue": -3,
-      "minValue": -10
+      "minValue": -10,
+      "maxValue": -3
     },
     "decoratedBool": {
       "type": "bool",
@@ -238,6 +238,10 @@
         "description": "An array."
       },
       "maxLength": 20
+    },
+    "nameofParam": {
+      "type": "string",
+      "defaultValue": "decoratedArray"
     }
   },
   "resources": []

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.sourcemap.bicep
@@ -433,10 +433,16 @@ param decoratedArray array = [
 //@      "type": "array",
 //@      "defaultValue": [
 //@      ],
-//@    }
+//@    },
     utcNow()
 //@        "[utcNow()]",
     newGuid()
 //@        "[newGuid()]"
 ]
+
+param nameofParam string = nameof(decoratedArray)
+//@    "nameofParam": {
+//@      "type": "string",
+//@      "defaultValue": "decoratedArray"
+//@    }
 

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8766450146642797131"
+      "templateHash": "11189823585100150972"
     }
   },
   "parameters": {
@@ -239,6 +239,10 @@
         "description": "An array."
       },
       "maxLength": 20
+    },
+    "nameofParam": {
+      "type": "string",
+      "defaultValue": "decoratedArray"
     }
   },
   "resources": {}

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.symbols.bicep
@@ -240,3 +240,6 @@ param decoratedArray array = [
     newGuid()
 ]
 
+param nameofParam string = nameof(decoratedArray)
+//@[6:17) Parameter nameofParam. Type: string. Declaration start char: 0, length: 49
+

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 /*
-//@[000:3162) ProgramSyntax
+//@[000:3213) ProgramSyntax
   This is a block comment.
 */
 //@[002:0004) ├─Token(NewLine) |\n\n|
@@ -1402,6 +1402,27 @@ param decoratedArray array = [
 //@[013:0014) |     ├─Token(NewLine) |\n|
 ]
 //@[000:0001) |     └─Token(RightSquare) |]|
-//@[001:0002) ├─Token(NewLine) |\n|
+//@[001:0003) ├─Token(NewLine) |\n\n|
+
+param nameofParam string = nameof(decoratedArray)
+//@[000:0049) ├─ParameterDeclarationSyntax
+//@[000:0005) | ├─Token(Identifier) |param|
+//@[006:0017) | ├─IdentifierSyntax
+//@[006:0017) | | └─Token(Identifier) |nameofParam|
+//@[018:0024) | ├─TypeVariableAccessSyntax
+//@[018:0024) | | └─IdentifierSyntax
+//@[018:0024) | |   └─Token(Identifier) |string|
+//@[025:0049) | └─ParameterDefaultValueSyntax
+//@[025:0026) |   ├─Token(Assignment) |=|
+//@[027:0049) |   └─FunctionCallSyntax
+//@[027:0033) |     ├─IdentifierSyntax
+//@[027:0033) |     | └─Token(Identifier) |nameof|
+//@[033:0034) |     ├─Token(LeftParen) |(|
+//@[034:0048) |     ├─FunctionArgumentSyntax
+//@[034:0048) |     | └─VariableAccessSyntax
+//@[034:0048) |     |   └─IdentifierSyntax
+//@[034:0048) |     |     └─Token(Identifier) |decoratedArray|
+//@[048:0049) |     └─Token(RightParen) |)|
+//@[049:0050) ├─Token(NewLine) |\n|
 
 //@[000:0000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.tokens.bicep
@@ -882,6 +882,17 @@ param decoratedArray array = [
 //@[013:014) NewLine |\n|
 ]
 //@[000:001) RightSquare |]|
-//@[001:002) NewLine |\n|
+//@[001:003) NewLine |\n\n|
+
+param nameofParam string = nameof(decoratedArray)
+//@[000:005) Identifier |param|
+//@[006:017) Identifier |nameofParam|
+//@[018:024) Identifier |string|
+//@[025:026) Assignment |=|
+//@[027:033) Identifier |nameof|
+//@[033:034) LeftParen |(|
+//@[034:048) Identifier |decoratedArray|
+//@[048:049) RightParen |)|
+//@[049:050) NewLine |\n|
 
 //@[000:000) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.bicep
@@ -510,5 +510,30 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
   resource primaryDb 'databases' = {
     name: 'primary-db'
     location: 'polandcentral'
+
+    resource threatProtection 'advancedThreatProtectionSettings' = {
+      name: 'Default'
+      properties: {
+        state: 'Enabled'
+      }
+    }
   }
+}
+
+//nameof
+var nameof1 = nameof(sqlServer)
+var nameof2 = nameof(sqlServer.location)
+var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
+var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
+var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
+
+var sqlConfig = {
+  westus: {}
+  server: {}
+  'my-rg': {}
+}
+resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  location: nameof(sqlConfig.westus)
+  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.bicep
@@ -532,6 +532,7 @@ var sqlConfig = {
   server: {}
   'my-rg': {}
 }
+
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
   name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
   location: nameof(sqlConfig.westus)

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.bicep
@@ -291,7 +291,7 @@ resource extension3 'My.Rp/extensionResource@2020-12-01' = {
 
 /*
   valid loop cases
-*/ 
+*/
 var storageAccounts = [
   {
     name: 'one'
@@ -332,7 +332,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
   properties: {
     subnets: [for j in range(0, 4): {
       // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
-     
+
       // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
@@ -529,12 +529,10 @@ var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
 
 var sqlConfig = {
   westus: {}
-  server: {}
-  'my-rg': {}
+  'server-name': {}
 }
 
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
-  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
   location: nameof(sqlConfig.westus)
-  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
@@ -543,5 +543,33 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
   resource primaryDb 'databases' = {
     name: 'primary-db'
     location: 'polandcentral'
+
+    resource threatProtection 'advancedThreatProtectionSettings' = {
+      name: 'Default'
+      properties: {
+        state: 'Enabled'
+      }
+    }
   }
 }
+
+//nameof
+var nameof1 = nameof(sqlServer)
+var nameof2 = nameof(sqlServer.location)
+var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
+var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
+var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
+
+var sqlConfig = {
+  westus: {}
+  server: {}
+  'my-rg': {}
+}
+
+resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  location: nameof(sqlConfig.westus)
+  scope: resourceGroup(nameof(sqlConfig['my-rg']))
+}
+
+//@[04:11) [no-unused-vars (Warning)] Variable "nameof1" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameof1|

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
@@ -45,7 +45,6 @@ resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
   properties: {
     supportsHttpsTrafficOnly: !false
     accessTier: true ? 'Hot' : 'Cold'
-//@[16:37) [BCP036 (Warning)] The property "accessTier" expected a value of type "'Cool' | 'Hot' | null" but the provided value is of type "'Cold' | 'Hot'". If this is an inaccuracy in the documentation, please report it to the Bicep Team. (CodeDescription: bicep(https://aka.ms/bicep-type-issues)) |true ? 'Hot' : 'Cold'|
     encryption: {
       keySource: 'Microsoft.Storage'
       services: {
@@ -85,7 +84,6 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
   }
   properties: {
     name: hostingPlanName // just hostingPlanName results in an error
-//@[04:08) [BCP037 (Warning)] The property "name" is not allowed on objects of type "AppServicePlanProperties". Permissible properties include "freeOfferExpirationTime", "hostingEnvironmentProfile", "hyperV", "isSpot", "isXenon", "maximumElasticWorkerCount", "perSiteScaling", "reserved", "spotExpirationTime", "targetWorkerCount", "targetWorkerSizeId", "workerTierName". If this is an inaccuracy in the documentation, please report it to the Bicep Team. (CodeDescription: bicep(https://aka.ms/bicep-type-issues)) |name|
   }
 }
 
@@ -97,7 +95,6 @@ var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 // this variable is not accessed anywhere in this template and depends on a run-time reference
 // it should not be present at all in the template output as there is nowhere logical to put it
 var cosmosDbEndpoint = cosmosDbRef.documentEndpoint
-//@[04:20) [no-unused-vars (Warning)] Variable "cosmosDbEndpoint" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |cosmosDbEndpoint|
 
 param webSiteName string
 param cosmosDb object
@@ -130,15 +127,12 @@ resource site 'Microsoft.Web/sites@2019-08-01' = {
 }
 
 var _siteApiVersion = site.apiVersion
-//@[04:19) [no-unused-vars (Warning)] Variable "_siteApiVersion" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |_siteApiVersion|
 var _siteType = site.type
-//@[04:13) [no-unused-vars (Warning)] Variable "_siteType" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |_siteType|
 
 output siteApiVersion string = site.apiVersion
 output siteType string = site.type
 
 resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
-//@[16:60) [no-deployments-resources (Warning)] Resource 'nested' of type 'Microsoft.Resources/deployments@2019-10-01' should instead be declared as a Bicep module. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-deployments-resources)) |'Microsoft.Resources/deployments@2019-10-01'|
   name: 'nestedTemplate1'
   properties: {
     mode: 'Incremental'
@@ -154,7 +148,6 @@ resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
 
 // should be able to access the read only properties
 resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
-//@[37:68) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2019-10-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Foo/foos@2019-10-01'|
   name: 'nestedTemplate1'
   properties: {
     otherId: nested.id
@@ -167,20 +160,15 @@ resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
 }
 
 resource resourceA 'My.Rp/typeA@2020-01-01' = {
-//@[19:43) [BCP081 (Warning)] Resource type "My.Rp/typeA@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/typeA@2020-01-01'|
   name: 'resourceA'
 }
 
 resource resourceB 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[19:49) [BCP081 (Warning)] Resource type "My.Rp/typeA/typeB@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/typeA/typeB@2020-01-01'|
   name: '${resourceA.name}/myName'
-//@[08:34) [use-parent-property (Warning)] Resource "resourceB" has its name formatted as a child of resource "resourceA". The syntax can be simplified by using the parent property. (CodeDescription: bicep core(https://aka.ms/bicep/linter/use-parent-property)) |'${resourceA.name}/myName'|
 }
 
 resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[19:49) [BCP081 (Warning)] Resource type "My.Rp/typeA/typeB@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/typeA/typeB@2020-01-01'|
   name: '${resourceA.name}/myName'
-//@[08:34) [use-parent-property (Warning)] Resource "resourceC" has its name formatted as a child of resource "resourceA". The syntax can be simplified by using the parent property. (CodeDescription: bicep core(https://aka.ms/bicep/linter/use-parent-property)) |'${resourceA.name}/myName'|
   properties: {
     aId: resourceA.id
     aType: resourceA.type
@@ -208,7 +196,6 @@ var resourceCRef = {
 var setResourceCRef = true
 
 resource resourceD 'My.Rp/typeD@2020-01-01' = {
-//@[19:43) [BCP081 (Warning)] Resource type "My.Rp/typeD@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/typeD@2020-01-01'|
   name: 'constant'
   properties: {
     runtime: varBRuntime
@@ -219,7 +206,6 @@ resource resourceD 'My.Rp/typeD@2020-01-01' = {
 
 var myInterpKey = 'abc'
 resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
-//@[28:53) [BCP081 (Warning)] Resource type "My.Rp/interp@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/interp@2020-01-01'|
   name: 'interpTest'
   properties: {
     '${myInterpKey}': 1
@@ -229,7 +215,6 @@ resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
 }
 
 resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
-//@[30:61) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/mockResource@2020-01-01'|
   name: 'test'
   properties: {
     // both key and value should be escaped in template output
@@ -267,24 +252,20 @@ resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
 }
 
 resource extension1 'My.Rp/extensionResource@2020-12-01' = {
-//@[20:56) [BCP081 (Warning)] Resource type "My.Rp/extensionResource@2020-12-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/extensionResource@2020-12-01'|
   name: 'extension'
   scope: vmWithCondition
 }
 
 resource extension2 'My.Rp/extensionResource@2020-12-01' = {
-//@[20:56) [BCP081 (Warning)] Resource type "My.Rp/extensionResource@2020-12-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/extensionResource@2020-12-01'|
   name: 'extension'
   scope: extension1
 }
 
 resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
-//@[31:62) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/mockResource@2020-01-01'|
   name: 'extensionDependencies'
   properties: {
     res1: vmWithCondition.id
     res1runtime: vmWithCondition.properties.something
-//@[44:53) [BCP053 (Warning)] The type "VirtualMachineProperties" does not contain property "something". Available properties include "additionalCapabilities", "availabilitySet", "billingProfile", "diagnosticsProfile", "evictionPolicy", "extensionsTimeBudget", "hardwareProfile", "host", "hostGroup", "instanceView", "licenseType", "networkProfile", "osProfile", "priority", "provisioningState", "proximityPlacementGroup", "securityProfile", "storageProfile", "virtualMachineScaleSet", "vmId". (CodeDescription: none) |something|
     res2: extension1.id
     res2runtime: extension1.properties.something
     res3: extension2.id
@@ -294,27 +275,23 @@ resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
 
 @sys.description('this is existing1')
 resource existing1 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[19:65) [BCP081 (Warning)] Resource type "Mock.Rp/existingExtensionResource@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Mock.Rp/existingExtensionResource@2020-01-01'|
   name: 'existing1'
   scope: extension1
 }
 
 resource existing2 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[09:18) [no-unused-existing-resources (Warning)] Existing resource "existing2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-existing-resources)) |existing2|
-//@[19:65) [BCP081 (Warning)] Resource type "Mock.Rp/existingExtensionResource@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Mock.Rp/existingExtensionResource@2020-01-01'|
   name: 'existing2'
   scope: existing1
 }
 
 resource extension3 'My.Rp/extensionResource@2020-12-01' = {
-//@[20:56) [BCP081 (Warning)] Resource type "My.Rp/extensionResource@2020-12-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'My.Rp/extensionResource@2020-12-01'|
   name: 'extension3'
   scope: existing1
 }
 
 /*
   valid loop cases
-*/ 
+*/
 var storageAccounts = [
   {
     name: 'one'
@@ -355,7 +332,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
   properties: {
     subnets: [for j in range(0, 4): {
       // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
-     
+
       // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
@@ -374,7 +351,6 @@ resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-
 
 // duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
 var canHaveDuplicatesAcrossScopes = 'hello'
-//@[04:33) [no-unused-vars (Warning)] Variable "canHaveDuplicatesAcrossScopes" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |canHaveDuplicatesAcrossScopes|
 resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
   name: 'vnet-${canHaveDuplicatesAcrossScopes}'
   properties: {
@@ -386,7 +362,6 @@ resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-
 
 // duplicate in global and multiple loop scopes are allowed (inner hides the outer)
 var duplicatesEverywhere = 'hello'
-//@[04:24) [no-unused-vars (Warning)] Variable "duplicatesEverywhere" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |duplicatesEverywhere|
 resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
   name: 'vnet-${duplicatesEverywhere}'
   properties: {
@@ -464,24 +439,20 @@ output p1_subnet1id string = p1_subnet1.id
 
 // parent property with extension resource
 resource p2_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
-//@[17:53) [BCP081 (Warning)] Resource type "Microsoft.Rp1/resource1@2020-06-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Rp1/resource1@2020-06-01'|
   name: 'res1'
 }
 
 resource p2_res1child 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[22:65) [BCP081 (Warning)] Resource type "Microsoft.Rp1/resource1/child1@2020-06-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Rp1/resource1/child1@2020-06-01'|
   parent: p2_res1
   name: 'child1'
 }
 
 resource p2_res2 'Microsoft.Rp2/resource2@2020-06-01' = {
-//@[17:53) [BCP081 (Warning)] Resource type "Microsoft.Rp2/resource2@2020-06-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Rp2/resource2@2020-06-01'|
   scope: p2_res1child
   name: 'res2'
 }
 
 resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
-//@[22:65) [BCP081 (Warning)] Resource type "Microsoft.Rp2/resource2/child2@2020-06-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Rp2/resource2/child2@2020-06-01'|
   parent: p2_res2
   name: 'child2'
 }
@@ -493,12 +464,10 @@ output p2_res2childid string = p2_res2child.id
 
 // parent property with 'existing' resource
 resource p3_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[17:53) [BCP081 (Warning)] Resource type "Microsoft.Rp1/resource1@2020-06-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Rp1/resource1@2020-06-01'|
   name: 'res1'
 }
 
 resource p3_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[19:62) [BCP081 (Warning)] Resource type "Microsoft.Rp1/resource1/child1@2020-06-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Rp1/resource1/child1@2020-06-01'|
   parent: p3_res1
   name: 'child1'
 }
@@ -510,13 +479,11 @@ output p3_res1childid string = p3_child1.id
 
 // parent & child with 'existing'
 resource p4_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[17:53) [BCP081 (Warning)] Resource type "Microsoft.Rp1/resource1@2020-06-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Rp1/resource1@2020-06-01'|
   scope: tenant()
   name: 'res1'
 }
 
 resource p4_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' existing = {
-//@[19:62) [BCP081 (Warning)] Resource type "Microsoft.Rp1/resource1/child1@2020-06-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (CodeDescription: none) |'Microsoft.Rp1/resource1/child1@2020-06-01'|
   parent: p4_res1
   name: 'child1'
 }
@@ -562,14 +529,11 @@ var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
 
 var sqlConfig = {
   westus: {}
-  server: {}
-  'my-rg': {}
+  'server-name': {}
 }
 
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
-  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
   location: nameof(sqlConfig.westus)
-  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }
 
-//@[04:11) [no-unused-vars (Warning)] Variable "nameof1" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameof1|

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.formatted.bicep
@@ -536,5 +536,31 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
   resource primaryDb 'databases' = {
     name: 'primary-db'
     location: 'polandcentral'
+
+    resource threatProtection 'advancedThreatProtectionSettings' = {
+      name: 'Default'
+      properties: {
+        state: 'Enabled'
+      }
+    }
   }
+}
+
+//nameof
+var nameof1 = nameof(sqlServer)
+var nameof2 = nameof(sqlServer.location)
+var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
+var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
+var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
+
+var sqlConfig = {
+  westus: {}
+  server: {}
+  'my-rg': {}
+}
+
+resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  location: nameof(sqlConfig.westus)
+  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.formatted.bicep
@@ -555,12 +555,10 @@ var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
 
 var sqlConfig = {
   westus: {}
-  server: {}
-  'my-rg': {}
+  'server-name': {}
 }
 
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
-  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
   location: nameof(sqlConfig.westus)
-  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.ir.bicep
@@ -1,5 +1,7 @@
 
-//@[000:13326) ProgramExpression
+//@[000:14050) ProgramExpression
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
 //@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
 //@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
 //@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
@@ -1345,8 +1347,8 @@ var dbs = ['db1', 'db2','db3']
 //@[018:00023) |   ├─StringLiteralExpression { Value = db2 }
 //@[024:00029) |   └─StringLiteralExpression { Value = db3 }
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
-//@[000:00416) ├─DeclaredResourceExpression
-//@[056:00416) | └─ObjectExpression
+//@[000:00572) ├─DeclaredResourceExpression
+//@[056:00572) | └─ObjectExpression
   name: 'sql-server-name'
   location: 'polandcentral'
 //@[002:00027) |   └─ObjectPropertyExpression
@@ -1369,14 +1371,49 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
   }]
 
   @description('Primary Sql Database')
-//@[002:00136) ├─DeclaredResourceExpression
+//@[002:00292) ├─DeclaredResourceExpression
 //@[015:00037) | ├─StringLiteralExpression { Value = Primary Sql Database }
   resource primaryDb 'databases' = {
-//@[035:00096) | ├─ObjectExpression
+//@[035:00252) | ├─ObjectExpression
     name: 'primary-db'
     location: 'polandcentral'
+
+    resource threatProtection 'advancedThreatProtectionSettings' = {
 //@[004:00029) | | └─ObjectPropertyExpression
 //@[004:00012) | |   ├─StringLiteralExpression { Value = location }
 //@[014:00029) | |   └─StringLiteralExpression { Value = polandcentral }
+      name: 'Default'
+      properties: {
+//@[004:00154) ├─DeclaredResourceExpression
+//@[067:00154) | ├─ObjectExpression
+        state: 'Enabled'
+      }
+//@[006:00054) | | └─ObjectPropertyExpression
+//@[006:00016) | |   ├─StringLiteralExpression { Value = properties }
+//@[018:00054) | |   └─ObjectExpression
+    }
+//@[008:00024) | |     └─ObjectPropertyExpression
+//@[008:00013) | |       ├─StringLiteralExpression { Value = state }
+//@[015:00024) | |       └─StringLiteralExpression { Value = Enabled }
   }
 }
+
+//nameof
+var nameof1 = nameof(sqlServer)
+var nameof2 = nameof(sqlServer.location)
+var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
+var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
+var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
+
+var sqlConfig = {
+  westus: {}
+  server: {}
+  'my-rg': {}
+}
+
+resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  location: nameof(sqlConfig.westus)
+  scope: resourceGroup(nameof(sqlConfig['my-rg']))
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.ir.bicep
@@ -1,235 +1,65 @@
 
-//@[000:14050) ProgramExpression
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
-//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
-//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
 @sys.description('this is basicStorage')
-//@[000:00225) ├─DeclaredResourceExpression
-//@[017:00039) | ├─StringLiteralExpression { Value = this is basicStorage }
 resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@[071:00183) | └─ObjectExpression
   name: 'basicblobs'
   location: 'westus'
-//@[002:00020) |   ├─ObjectPropertyExpression
-//@[002:00010) |   | ├─StringLiteralExpression { Value = location }
-//@[012:00020) |   | └─StringLiteralExpression { Value = westus }
   kind: 'BlobStorage'
-//@[002:00021) |   ├─ObjectPropertyExpression
-//@[002:00006) |   | ├─StringLiteralExpression { Value = kind }
-//@[008:00021) |   | └─StringLiteralExpression { Value = BlobStorage }
   sku: {
-//@[002:00039) |   └─ObjectPropertyExpression
-//@[002:00005) |     ├─StringLiteralExpression { Value = sku }
-//@[007:00039) |     └─ObjectExpression
     name: 'Standard_GRS'
-//@[004:00024) |       └─ObjectPropertyExpression
-//@[004:00008) |         ├─StringLiteralExpression { Value = name }
-//@[010:00024) |         └─StringLiteralExpression { Value = Standard_GRS }
   }
 }
 
 @sys.description('this is dnsZone')
-//@[000:00140) ├─DeclaredResourceExpression
-//@[017:00034) | ├─StringLiteralExpression { Value = this is dnsZone }
 resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
-//@[059:00103) | └─ObjectExpression
   name: 'myZone'
   location: 'global'
-//@[002:00020) |   └─ObjectPropertyExpression
-//@[002:00010) |     ├─StringLiteralExpression { Value = location }
-//@[012:00020) |     └─StringLiteralExpression { Value = global }
 }
 
 resource myStorageAccount 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@[000:00469) ├─DeclaredResourceExpression
-//@[075:00469) | └─ObjectExpression
   name: 'myencryptedone'
   location: 'eastus2'
-//@[002:00021) |   ├─ObjectPropertyExpression
-//@[002:00010) |   | ├─StringLiteralExpression { Value = location }
-//@[012:00021) |   | └─StringLiteralExpression { Value = eastus2 }
   properties: {
-//@[002:00277) |   ├─ObjectPropertyExpression
-//@[002:00012) |   | ├─StringLiteralExpression { Value = properties }
-//@[014:00277) |   | └─ObjectExpression
     supportsHttpsTrafficOnly: true
-//@[004:00034) |   |   ├─ObjectPropertyExpression
-//@[004:00028) |   |   | ├─StringLiteralExpression { Value = supportsHttpsTrafficOnly }
-//@[030:00034) |   |   | └─BooleanLiteralExpression { Value = True }
     accessTier: 'Hot'
-//@[004:00021) |   |   ├─ObjectPropertyExpression
-//@[004:00014) |   |   | ├─StringLiteralExpression { Value = accessTier }
-//@[016:00021) |   |   | └─StringLiteralExpression { Value = Hot }
     encryption: {
-//@[004:00196) |   |   └─ObjectPropertyExpression
-//@[004:00014) |   |     ├─StringLiteralExpression { Value = encryption }
-//@[016:00196) |   |     └─ObjectExpression
       keySource: 'Microsoft.Storage'
-//@[006:00036) |   |       ├─ObjectPropertyExpression
-//@[006:00015) |   |       | ├─StringLiteralExpression { Value = keySource }
-//@[017:00036) |   |       | └─StringLiteralExpression { Value = Microsoft.Storage }
       services: {
-//@[006:00132) |   |       └─ObjectPropertyExpression
-//@[006:00014) |   |         ├─StringLiteralExpression { Value = services }
-//@[016:00132) |   |         └─ObjectExpression
         blob: {
-//@[008:00051) |   |           ├─ObjectPropertyExpression
-//@[008:00012) |   |           | ├─StringLiteralExpression { Value = blob }
-//@[014:00051) |   |           | └─ObjectExpression
           enabled: true
-//@[010:00023) |   |           |   └─ObjectPropertyExpression
-//@[010:00017) |   |           |     ├─StringLiteralExpression { Value = enabled }
-//@[019:00023) |   |           |     └─BooleanLiteralExpression { Value = True }
         }
         file: {
-//@[008:00051) |   |           └─ObjectPropertyExpression
-//@[008:00012) |   |             ├─StringLiteralExpression { Value = file }
-//@[014:00051) |   |             └─ObjectExpression
           enabled: true
-//@[010:00023) |   |               └─ObjectPropertyExpression
-//@[010:00017) |   |                 ├─StringLiteralExpression { Value = enabled }
-//@[019:00023) |   |                 └─BooleanLiteralExpression { Value = True }
         }
       }
     }
   }
   kind: 'StorageV2'
-//@[002:00019) |   ├─ObjectPropertyExpression
-//@[002:00006) |   | ├─StringLiteralExpression { Value = kind }
-//@[008:00019) |   | └─StringLiteralExpression { Value = StorageV2 }
   sku: {
-//@[002:00039) |   └─ObjectPropertyExpression
-//@[002:00005) |     ├─StringLiteralExpression { Value = sku }
-//@[007:00039) |     └─ObjectExpression
     name: 'Standard_LRS'
-//@[004:00024) |       └─ObjectPropertyExpression
-//@[004:00008) |         ├─StringLiteralExpression { Value = name }
-//@[010:00024) |         └─StringLiteralExpression { Value = Standard_LRS }
   }
 }
 
 resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@[000:00539) ├─DeclaredResourceExpression
-//@[074:00539) | ├─ObjectExpression
   name: 'myencryptedone2'
   location: 'eastus2'
-//@[002:00021) | | ├─ObjectPropertyExpression
-//@[002:00010) | | | ├─StringLiteralExpression { Value = location }
-//@[012:00021) | | | └─StringLiteralExpression { Value = eastus2 }
   properties: {
-//@[002:00304) | | ├─ObjectPropertyExpression
-//@[002:00012) | | | ├─StringLiteralExpression { Value = properties }
-//@[014:00304) | | | └─ObjectExpression
     supportsHttpsTrafficOnly: !false
-//@[004:00036) | | |   ├─ObjectPropertyExpression
-//@[004:00028) | | |   | ├─StringLiteralExpression { Value = supportsHttpsTrafficOnly }
-//@[030:00036) | | |   | └─UnaryExpression { Operator = Not }
-//@[031:00036) | | |   |   └─BooleanLiteralExpression { Value = False }
     accessTier: true ? 'Hot' : 'Cold'
-//@[004:00037) | | |   ├─ObjectPropertyExpression
-//@[004:00014) | | |   | ├─StringLiteralExpression { Value = accessTier }
-//@[016:00037) | | |   | └─TernaryExpression
-//@[016:00020) | | |   |   ├─BooleanLiteralExpression { Value = True }
-//@[023:00028) | | |   |   ├─StringLiteralExpression { Value = Hot }
-//@[031:00037) | | |   |   └─StringLiteralExpression { Value = Cold }
     encryption: {
-//@[004:00205) | | |   └─ObjectPropertyExpression
-//@[004:00014) | | |     ├─StringLiteralExpression { Value = encryption }
-//@[016:00205) | | |     └─ObjectExpression
       keySource: 'Microsoft.Storage'
-//@[006:00036) | | |       ├─ObjectPropertyExpression
-//@[006:00015) | | |       | ├─StringLiteralExpression { Value = keySource }
-//@[017:00036) | | |       | └─StringLiteralExpression { Value = Microsoft.Storage }
       services: {
-//@[006:00141) | | |       └─ObjectPropertyExpression
-//@[006:00014) | | |         ├─StringLiteralExpression { Value = services }
-//@[016:00141) | | |         └─ObjectExpression
         blob: {
-//@[008:00060) | | |           ├─ObjectPropertyExpression
-//@[008:00012) | | |           | ├─StringLiteralExpression { Value = blob }
-//@[014:00060) | | |           | └─ObjectExpression
           enabled: true || false
-//@[010:00032) | | |           |   └─ObjectPropertyExpression
-//@[010:00017) | | |           |     ├─StringLiteralExpression { Value = enabled }
-//@[019:00032) | | |           |     └─BinaryExpression { Operator = LogicalOr }
-//@[019:00023) | | |           |       ├─BooleanLiteralExpression { Value = True }
-//@[027:00032) | | |           |       └─BooleanLiteralExpression { Value = False }
         }
         file: {
-//@[008:00051) | | |           └─ObjectPropertyExpression
-//@[008:00012) | | |             ├─StringLiteralExpression { Value = file }
-//@[014:00051) | | |             └─ObjectExpression
           enabled: true
-//@[010:00023) | | |               └─ObjectPropertyExpression
-//@[010:00017) | | |                 ├─StringLiteralExpression { Value = enabled }
-//@[019:00023) | | |                 └─BooleanLiteralExpression { Value = True }
         }
       }
     }
   }
   kind: 'StorageV2'
-//@[002:00019) | | ├─ObjectPropertyExpression
-//@[002:00006) | | | ├─StringLiteralExpression { Value = kind }
-//@[008:00019) | | | └─StringLiteralExpression { Value = StorageV2 }
   sku: {
-//@[002:00039) | | └─ObjectPropertyExpression
-//@[002:00005) | |   ├─StringLiteralExpression { Value = sku }
-//@[007:00039) | |   └─ObjectExpression
     name: 'Standard_LRS'
-//@[004:00024) | |     └─ObjectPropertyExpression
-//@[004:00008) | |       ├─StringLiteralExpression { Value = name }
-//@[010:00024) | |       └─StringLiteralExpression { Value = Standard_LRS }
   }
   dependsOn: [
     myStorageAccount
@@ -237,69 +67,29 @@ resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
 }
 
 param applicationName string = 'to-do-app${uniqueString(resourceGroup().id)}'
-//@[000:00077) ├─DeclaredParameterExpression { Name = applicationName }
-//@[022:00028) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[031:00077) | └─InterpolatedStringExpression
-//@[043:00075) |   └─FunctionCallExpression { Name = uniqueString }
-//@[056:00074) |     └─PropertyAccessExpression { PropertyName = id }
-//@[056:00071) |       └─FunctionCallExpression { Name = resourceGroup }
 var hostingPlanName = applicationName // why not just use the param directly?
-//@[000:00037) ├─DeclaredVariableExpression { Name = hostingPlanName }
-//@[022:00037) | └─ParametersReferenceExpression { Parameter = applicationName }
 
 param appServicePlanTier string
-//@[000:00031) ├─DeclaredParameterExpression { Name = appServicePlanTier }
-//@[025:00031) | └─AmbientTypeReferenceExpression { Name = string }
 param appServicePlanInstances int
-//@[000:00033) ├─DeclaredParameterExpression { Name = appServicePlanInstances }
-//@[030:00033) | └─AmbientTypeReferenceExpression { Name = int }
 
 var location = resourceGroup().location
-//@[000:00039) ├─DeclaredVariableExpression { Name = location }
-//@[015:00039) | └─PropertyAccessExpression { PropertyName = location }
-//@[015:00030) |   └─FunctionCallExpression { Name = resourceGroup }
 
 resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
-//@[000:00371) ├─DeclaredResourceExpression
-//@[055:00371) | └─ObjectExpression
   // dependsOn: resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosAccountName)
   name: hostingPlanName
   location: location
-//@[002:00020) |   ├─ObjectPropertyExpression
-//@[002:00010) |   | ├─StringLiteralExpression { Value = location }
-//@[012:00020) |   | └─VariableReferenceExpression { Variable = location }
   sku: {
-//@[002:00082) |   ├─ObjectPropertyExpression
-//@[002:00005) |   | ├─StringLiteralExpression { Value = sku }
-//@[007:00082) |   | └─ObjectExpression
     name: appServicePlanTier
-//@[004:00028) |   |   ├─ObjectPropertyExpression
-//@[004:00008) |   |   | ├─StringLiteralExpression { Value = name }
-//@[010:00028) |   |   | └─ParametersReferenceExpression { Parameter = appServicePlanTier }
     capacity: appServicePlanInstances
-//@[004:00037) |   |   └─ObjectPropertyExpression
-//@[004:00012) |   |     ├─StringLiteralExpression { Value = capacity }
-//@[014:00037) |   |     └─ParametersReferenceExpression { Parameter = appServicePlanInstances }
   }
   properties: {
-//@[002:00091) |   └─ObjectPropertyExpression
-//@[002:00012) |     ├─StringLiteralExpression { Value = properties }
-//@[014:00091) |     └─ObjectExpression
     name: hostingPlanName // just hostingPlanName results in an error
-//@[004:00025) |       └─ObjectPropertyExpression
-//@[004:00008) |         ├─StringLiteralExpression { Value = name }
-//@[010:00025) |         └─VariableReferenceExpression { Variable = hostingPlanName }
   }
 }
 
 var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
-//@[000:00107) ├─DeclaredVariableExpression { Name = cosmosDbResourceId }
-//@[025:00107) | └─FunctionCallExpression { Name = resourceId }
-//@[036:00075) |   ├─StringLiteralExpression { Value = Microsoft.DocumentDB/databaseAccounts }
 // comment
 cosmosDb.account)
-//@[000:00016) |   └─PropertyAccessExpression { PropertyName = account }
-//@[000:00008) |     └─ParametersReferenceExpression { Parameter = cosmosDb }
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference
@@ -307,82 +97,29 @@ var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 var cosmosDbEndpoint = cosmosDbRef.documentEndpoint
 
 param webSiteName string
-//@[000:00024) ├─DeclaredParameterExpression { Name = webSiteName }
-//@[018:00024) | └─AmbientTypeReferenceExpression { Name = string }
 param cosmosDb object
-//@[000:00021) ├─DeclaredParameterExpression { Name = cosmosDb }
-//@[015:00021) | └─AmbientTypeReferenceExpression { Name = object }
 resource site 'Microsoft.Web/sites@2019-08-01' = {
-//@[000:00689) ├─DeclaredResourceExpression
-//@[049:00689) | └─ObjectExpression
   name: webSiteName
   location: location
-//@[002:00020) |   ├─ObjectPropertyExpression
-//@[002:00010) |   | ├─StringLiteralExpression { Value = location }
-//@[012:00020) |   | └─VariableReferenceExpression { Variable = location }
   properties: {
-//@[002:00591) |   └─ObjectPropertyExpression
-//@[002:00012) |     ├─StringLiteralExpression { Value = properties }
-//@[014:00591) |     └─ObjectExpression
     // not yet supported // serverFarmId: farm.id
     siteConfig: {
-//@[004:00518) |       └─ObjectPropertyExpression
-//@[004:00014) |         ├─StringLiteralExpression { Value = siteConfig }
-//@[016:00518) |         └─ObjectExpression
       appSettings: [
-//@[006:00492) |           └─ObjectPropertyExpression
-//@[006:00017) |             ├─StringLiteralExpression { Value = appSettings }
-//@[019:00492) |             └─ArrayExpression
         {
-//@[008:00121) |               ├─ObjectExpression
           name: 'CosmosDb:Account'
-//@[010:00034) |               | ├─ObjectPropertyExpression
-//@[010:00014) |               | | ├─StringLiteralExpression { Value = name }
-//@[016:00034) |               | | └─StringLiteralExpression { Value = CosmosDb:Account }
           value: reference(cosmosDbResourceId).documentEndpoint
-//@[010:00063) |               | └─ObjectPropertyExpression
-//@[010:00015) |               |   ├─StringLiteralExpression { Value = value }
-//@[017:00063) |               |   └─PropertyAccessExpression { PropertyName = documentEndpoint }
-//@[017:00046) |               |     └─FunctionCallExpression { Name = reference }
-//@[027:00045) |               |       └─VariableReferenceExpression { Variable = cosmosDbResourceId }
         }
         {
-//@[008:00130) |               ├─ObjectExpression
           name: 'CosmosDb:Key'
-//@[010:00030) |               | ├─ObjectPropertyExpression
-//@[010:00014) |               | | ├─StringLiteralExpression { Value = name }
-//@[016:00030) |               | | └─StringLiteralExpression { Value = CosmosDb:Key }
           value: listKeys(cosmosDbResourceId, '2020-04-01').primaryMasterKey
-//@[010:00076) |               | └─ObjectPropertyExpression
-//@[010:00015) |               |   ├─StringLiteralExpression { Value = value }
-//@[017:00076) |               |   └─PropertyAccessExpression { PropertyName = primaryMasterKey }
-//@[017:00059) |               |     └─FunctionCallExpression { Name = listKeys }
-//@[026:00044) |               |       ├─VariableReferenceExpression { Variable = cosmosDbResourceId }
-//@[046:00058) |               |       └─StringLiteralExpression { Value = 2020-04-01 }
         }
         {
-//@[008:00101) |               ├─ObjectExpression
           name: 'CosmosDb:DatabaseName'
-//@[010:00039) |               | ├─ObjectPropertyExpression
-//@[010:00014) |               | | ├─StringLiteralExpression { Value = name }
-//@[016:00039) |               | | └─StringLiteralExpression { Value = CosmosDb:DatabaseName }
           value: cosmosDb.databaseName
-//@[010:00038) |               | └─ObjectPropertyExpression
-//@[010:00015) |               |   ├─StringLiteralExpression { Value = value }
-//@[017:00038) |               |   └─PropertyAccessExpression { PropertyName = databaseName }
-//@[017:00025) |               |     └─ParametersReferenceExpression { Parameter = cosmosDb }
         }
         {
-//@[008:00103) |               └─ObjectExpression
           name: 'CosmosDb:ContainerName'
-//@[010:00040) |                 ├─ObjectPropertyExpression
-//@[010:00014) |                 | ├─StringLiteralExpression { Value = name }
-//@[016:00040) |                 | └─StringLiteralExpression { Value = CosmosDb:ContainerName }
           value: cosmosDb.containerName
-//@[010:00039) |                 └─ObjectPropertyExpression
-//@[010:00015) |                   ├─StringLiteralExpression { Value = value }
-//@[017:00039) |                   └─PropertyAccessExpression { PropertyName = containerName }
-//@[017:00025) |                     └─ParametersReferenceExpression { Parameter = cosmosDb }
         }
       ]
     }
@@ -390,54 +127,20 @@ resource site 'Microsoft.Web/sites@2019-08-01' = {
 }
 
 var _siteApiVersion = site.apiVersion
-//@[000:00037) ├─DeclaredVariableExpression { Name = _siteApiVersion }
-//@[022:00037) | └─PropertyAccessExpression { PropertyName = apiVersion }
-//@[022:00026) |   └─ResourceReferenceExpression
 var _siteType = site.type
-//@[000:00025) ├─DeclaredVariableExpression { Name = _siteType }
-//@[016:00025) | └─PropertyAccessExpression { PropertyName = type }
-//@[016:00020) |   └─ResourceReferenceExpression
 
 output siteApiVersion string = site.apiVersion
-//@[000:00046) ├─DeclaredOutputExpression { Name = siteApiVersion }
-//@[022:00028) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[031:00046) | └─PropertyAccessExpression { PropertyName = apiVersion }
-//@[031:00035) |   └─ResourceReferenceExpression
 output siteType string = site.type
-//@[000:00034) ├─DeclaredOutputExpression { Name = siteType }
-//@[016:00022) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[025:00034) | └─PropertyAccessExpression { PropertyName = type }
-//@[025:00029) |   └─ResourceReferenceExpression
 
 resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
-//@[000:00354) ├─DeclaredResourceExpression
-//@[063:00354) | └─ObjectExpression
   name: 'nestedTemplate1'
   properties: {
-//@[002:00258) |   └─ObjectPropertyExpression
-//@[002:00012) |     ├─StringLiteralExpression { Value = properties }
-//@[014:00258) |     └─ObjectExpression
     mode: 'Incremental'
-//@[004:00023) |       ├─ObjectPropertyExpression
-//@[004:00008) |       | ├─StringLiteralExpression { Value = mode }
-//@[010:00023) |       | └─StringLiteralExpression { Value = Incremental }
     template: {
-//@[004:00211) |       └─ObjectPropertyExpression
-//@[004:00012) |         ├─StringLiteralExpression { Value = template }
-//@[014:00211) |         └─ObjectExpression
       // string key value
       '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-//@[006:00098) |           ├─ObjectPropertyExpression
-//@[006:00015) |           | ├─StringLiteralExpression { Value = $schema }
-//@[017:00098) |           | └─StringLiteralExpression { Value = https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json# }
       contentVersion: '1.0.0.0'
-//@[006:00031) |           ├─ObjectPropertyExpression
-//@[006:00020) |           | ├─StringLiteralExpression { Value = contentVersion }
-//@[022:00031) |           | └─StringLiteralExpression { Value = 1.0.0.0 }
       resources: [
-//@[006:00027) |           └─ObjectPropertyExpression
-//@[006:00015) |             ├─StringLiteralExpression { Value = resources }
-//@[017:00027) |             └─ArrayExpression
       ]
     }
   }
@@ -445,613 +148,225 @@ resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
 
 // should be able to access the read only properties
 resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
-//@[000:00284) ├─DeclaredResourceExpression
-//@[071:00284) | ├─ObjectExpression
   name: 'nestedTemplate1'
   properties: {
-//@[002:00180) | | └─ObjectPropertyExpression
-//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
-//@[014:00180) | |   └─ObjectExpression
     otherId: nested.id
-//@[004:00022) | |     ├─ObjectPropertyExpression
-//@[004:00011) | |     | ├─StringLiteralExpression { Value = otherId }
-//@[013:00022) | |     | └─PropertyAccessExpression { PropertyName = id }
-//@[013:00019) | |     |   └─ResourceReferenceExpression
     otherName: nested.name
-//@[004:00026) | |     ├─ObjectPropertyExpression
-//@[004:00013) | |     | ├─StringLiteralExpression { Value = otherName }
-//@[015:00026) | |     | └─PropertyAccessExpression { PropertyName = name }
-//@[015:00021) | |     |   └─ResourceReferenceExpression
     otherVersion: nested.apiVersion
-//@[004:00035) | |     ├─ObjectPropertyExpression
-//@[004:00016) | |     | ├─StringLiteralExpression { Value = otherVersion }
-//@[018:00035) | |     | └─PropertyAccessExpression { PropertyName = apiVersion }
-//@[018:00024) | |     |   └─ResourceReferenceExpression
     otherType: nested.type
-//@[004:00026) | |     ├─ObjectPropertyExpression
-//@[004:00013) | |     | ├─StringLiteralExpression { Value = otherType }
-//@[015:00026) | |     | └─PropertyAccessExpression { PropertyName = type }
-//@[015:00021) | |     |   └─ResourceReferenceExpression
 
     otherThings: nested.properties.mode
-//@[004:00039) | |     └─ObjectPropertyExpression
-//@[004:00015) | |       ├─StringLiteralExpression { Value = otherThings }
-//@[017:00039) | |       └─AccessChainExpression
-//@[017:00034) | |         ├─PropertyAccessExpression { PropertyName = properties }
-//@[017:00023) | |         | └─ResourceReferenceExpression
-//@[035:00039) | |         └─StringLiteralExpression { Value = mode }
   }
 }
 
 resource resourceA 'My.Rp/typeA@2020-01-01' = {
-//@[000:00071) ├─DeclaredResourceExpression
-//@[046:00071) | └─ObjectExpression
   name: 'resourceA'
 }
 
 resource resourceB 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[000:00092) ├─DeclaredResourceExpression
-//@[052:00092) | ├─ObjectExpression
   name: '${resourceA.name}/myName'
 }
 
 resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[000:00269) ├─DeclaredResourceExpression
-//@[052:00269) | ├─ObjectExpression
   name: '${resourceA.name}/myName'
   properties: {
-//@[002:00175) | | └─ObjectPropertyExpression
-//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
-//@[014:00175) | |   └─ObjectExpression
     aId: resourceA.id
-//@[004:00021) | |     ├─ObjectPropertyExpression
-//@[004:00007) | |     | ├─StringLiteralExpression { Value = aId }
-//@[009:00021) | |     | └─PropertyAccessExpression { PropertyName = id }
-//@[009:00018) | |     |   └─ResourceReferenceExpression
     aType: resourceA.type
-//@[004:00025) | |     ├─ObjectPropertyExpression
-//@[004:00009) | |     | ├─StringLiteralExpression { Value = aType }
-//@[011:00025) | |     | └─PropertyAccessExpression { PropertyName = type }
-//@[011:00020) | |     |   └─ResourceReferenceExpression
     aName: resourceA.name
-//@[004:00025) | |     ├─ObjectPropertyExpression
-//@[004:00009) | |     | ├─StringLiteralExpression { Value = aName }
-//@[011:00025) | |     | └─PropertyAccessExpression { PropertyName = name }
-//@[011:00020) | |     |   └─ResourceReferenceExpression
     aApiVersion: resourceA.apiVersion
-//@[004:00037) | |     ├─ObjectPropertyExpression
-//@[004:00015) | |     | ├─StringLiteralExpression { Value = aApiVersion }
-//@[017:00037) | |     | └─PropertyAccessExpression { PropertyName = apiVersion }
-//@[017:00026) | |     |   └─ResourceReferenceExpression
     bProperties: resourceB.properties
-//@[004:00037) | |     └─ObjectPropertyExpression
-//@[004:00015) | |       ├─StringLiteralExpression { Value = bProperties }
-//@[017:00037) | |       └─PropertyAccessExpression { PropertyName = properties }
-//@[017:00026) | |         └─ResourceReferenceExpression
   }
 }
 
 var varARuntime = {
-//@[018:00155) | |     |   └─ObjectExpression
   bId: resourceB.id
-//@[002:00019) | |     |     ├─ObjectPropertyExpression
-//@[002:00005) | |     |     | ├─StringLiteralExpression { Value = bId }
-//@[007:00019) | |     |     | └─PropertyAccessExpression { PropertyName = id }
-//@[007:00016) | |     |     |   └─ResourceReferenceExpression
   bType: resourceB.type
-//@[002:00023) | |     |     ├─ObjectPropertyExpression
-//@[002:00007) | |     |     | ├─StringLiteralExpression { Value = bType }
-//@[009:00023) | |     |     | └─PropertyAccessExpression { PropertyName = type }
-//@[009:00018) | |     |     |   └─ResourceReferenceExpression
   bName: resourceB.name
-//@[002:00023) | |     |     ├─ObjectPropertyExpression
-//@[002:00007) | |     |     | ├─StringLiteralExpression { Value = bName }
-//@[009:00023) | |     |     | └─PropertyAccessExpression { PropertyName = name }
-//@[009:00018) | |     |     |   └─ResourceReferenceExpression
   bApiVersion: resourceB.apiVersion
-//@[002:00035) | |     |     ├─ObjectPropertyExpression
-//@[002:00013) | |     |     | ├─StringLiteralExpression { Value = bApiVersion }
-//@[015:00035) | |     |     | └─PropertyAccessExpression { PropertyName = apiVersion }
-//@[015:00024) | |     |     |   └─ResourceReferenceExpression
   aKind: resourceA.kind
-//@[002:00023) | |     |     └─ObjectPropertyExpression
-//@[002:00007) | |     |       ├─StringLiteralExpression { Value = aKind }
-//@[009:00023) | |     |       └─PropertyAccessExpression { PropertyName = kind }
-//@[009:00018) | |     |         └─ResourceReferenceExpression
 }
 
 var varBRuntime = [
-//@[018:00037) | |     | └─ArrayExpression
   varARuntime
 ]
 
 var resourceCRef = {
-//@[000:00043) ├─DeclaredVariableExpression { Name = resourceCRef }
-//@[019:00043) | └─ObjectExpression
   id: resourceC.id
-//@[002:00018) |   └─ObjectPropertyExpression
-//@[002:00004) |     ├─StringLiteralExpression { Value = id }
-//@[006:00018) |     └─PropertyAccessExpression { PropertyName = id }
-//@[006:00015) |       └─ResourceReferenceExpression
 }
 var setResourceCRef = true
-//@[000:00026) ├─DeclaredVariableExpression { Name = setResourceCRef }
-//@[022:00026) | └─BooleanLiteralExpression { Value = True }
 
 resource resourceD 'My.Rp/typeD@2020-01-01' = {
-//@[000:00231) ├─DeclaredResourceExpression
-//@[046:00231) | ├─ObjectExpression
   name: 'constant'
   properties: {
-//@[002:00159) | | └─ObjectPropertyExpression
-//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
-//@[014:00159) | |   └─ObjectExpression
     runtime: varBRuntime
-//@[004:00024) | |     ├─ObjectPropertyExpression
-//@[004:00011) | |     | ├─StringLiteralExpression { Value = runtime }
     // repro for https://github.com/Azure/bicep/issues/316
     repro316: setResourceCRef ? resourceCRef : null
-//@[004:00051) | |     └─ObjectPropertyExpression
-//@[004:00012) | |       ├─StringLiteralExpression { Value = repro316 }
-//@[014:00051) | |       └─TernaryExpression
-//@[014:00029) | |         ├─VariableReferenceExpression { Variable = setResourceCRef }
-//@[032:00044) | |         ├─VariableReferenceExpression { Variable = resourceCRef }
-//@[047:00051) | |         └─NullLiteralExpression
   }
 }
 
 var myInterpKey = 'abc'
-//@[000:00023) ├─DeclaredVariableExpression { Name = myInterpKey }
-//@[018:00023) | └─StringLiteralExpression { Value = abc }
 resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
-//@[000:00202) ├─DeclaredResourceExpression
-//@[056:00202) | └─ObjectExpression
   name: 'interpTest'
   properties: {
-//@[002:00118) |   └─ObjectPropertyExpression
-//@[002:00012) |     ├─StringLiteralExpression { Value = properties }
-//@[014:00118) |     └─ObjectExpression
     '${myInterpKey}': 1
-//@[004:00023) |       ├─ObjectPropertyExpression
-//@[004:00020) |       | ├─InterpolatedStringExpression
-//@[007:00018) |       | | └─VariableReferenceExpression { Variable = myInterpKey }
-//@[022:00023) |       | └─IntegerLiteralExpression { Value = 1 }
     'abc${myInterpKey}def': 2
-//@[004:00029) |       ├─ObjectPropertyExpression
-//@[004:00026) |       | ├─InterpolatedStringExpression
-//@[010:00021) |       | | └─VariableReferenceExpression { Variable = myInterpKey }
-//@[028:00029) |       | └─IntegerLiteralExpression { Value = 2 }
     '${myInterpKey}abc${myInterpKey}': 3
-//@[004:00040) |       └─ObjectPropertyExpression
-//@[004:00037) |         ├─InterpolatedStringExpression
-//@[007:00018) |         | ├─VariableReferenceExpression { Variable = myInterpKey }
-//@[024:00035) |         | └─VariableReferenceExpression { Variable = myInterpKey }
-//@[039:00040) |         └─IntegerLiteralExpression { Value = 3 }
   }
 }
 
 resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
-//@[000:00234) ├─DeclaredResourceExpression
-//@[064:00234) | └─ObjectExpression
   name: 'test'
   properties: {
-//@[002:00148) |   └─ObjectPropertyExpression
-//@[002:00012) |     ├─StringLiteralExpression { Value = properties }
-//@[014:00148) |     └─ObjectExpression
     // both key and value should be escaped in template output
     '[resourceGroup().location]': '[resourceGroup().location]'
-//@[004:00062) |       └─ObjectPropertyExpression
-//@[004:00032) |         ├─StringLiteralExpression { Value = [resourceGroup().location] }
-//@[034:00062) |         └─StringLiteralExpression { Value = [resourceGroup().location] }
   }
 }
 
 param shouldDeployVm bool = true
-//@[000:00032) ├─DeclaredParameterExpression { Name = shouldDeployVm }
-//@[021:00025) | ├─AmbientTypeReferenceExpression { Name = bool }
-//@[028:00032) | └─BooleanLiteralExpression { Value = True }
 
 @sys.description('this is vmWithCondition')
-//@[000:00308) ├─DeclaredResourceExpression
-//@[017:00042) | ├─StringLiteralExpression { Value = this is vmWithCondition }
 resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (shouldDeployVm) {
-//@[078:00092) | └─ConditionExpression
-//@[078:00092) |   ├─ParametersReferenceExpression { Parameter = shouldDeployVm }
-//@[094:00263) |   └─ObjectExpression
   name: 'vmName'
   location: 'westus'
-//@[002:00020) |     ├─ObjectPropertyExpression
-//@[002:00010) |     | ├─StringLiteralExpression { Value = location }
-//@[012:00020) |     | └─StringLiteralExpression { Value = westus }
   properties: {
-//@[002:00123) |     └─ObjectPropertyExpression
-//@[002:00012) |       ├─StringLiteralExpression { Value = properties }
-//@[014:00123) |       └─ObjectExpression
     osProfile: {
-//@[004:00101) |         └─ObjectPropertyExpression
-//@[004:00013) |           ├─StringLiteralExpression { Value = osProfile }
-//@[015:00101) |           └─ObjectExpression
       windowsConfiguration: {
-//@[006:00076) |             └─ObjectPropertyExpression
-//@[006:00026) |               ├─StringLiteralExpression { Value = windowsConfiguration }
-//@[028:00076) |               └─ObjectExpression
         enableAutomaticUpdates: true
-//@[008:00036) |                 └─ObjectPropertyExpression
-//@[008:00030) |                   ├─StringLiteralExpression { Value = enableAutomaticUpdates }
-//@[032:00036) |                   └─BooleanLiteralExpression { Value = True }
       }
     }
   }
 }
 
 @sys.description('this is another vmWithCondition')
-//@[000:00339) ├─DeclaredResourceExpression
-//@[017:00050) | ├─StringLiteralExpression { Value = this is another vmWithCondition }
 resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
                     if (shouldDeployVm) {
-//@[024:00038) | └─ConditionExpression
-//@[024:00038) |   ├─ParametersReferenceExpression { Parameter = shouldDeployVm }
-//@[040:00210) |   └─ObjectExpression
   name: 'vmName2'
   location: 'westus'
-//@[002:00020) |     ├─ObjectPropertyExpression
-//@[002:00010) |     | ├─StringLiteralExpression { Value = location }
-//@[012:00020) |     | └─StringLiteralExpression { Value = westus }
   properties: {
-//@[002:00123) |     └─ObjectPropertyExpression
-//@[002:00012) |       ├─StringLiteralExpression { Value = properties }
-//@[014:00123) |       └─ObjectExpression
     osProfile: {
-//@[004:00101) |         └─ObjectPropertyExpression
-//@[004:00013) |           ├─StringLiteralExpression { Value = osProfile }
-//@[015:00101) |           └─ObjectExpression
       windowsConfiguration: {
-//@[006:00076) |             └─ObjectPropertyExpression
-//@[006:00026) |               ├─StringLiteralExpression { Value = windowsConfiguration }
-//@[028:00076) |               └─ObjectExpression
         enableAutomaticUpdates: true
-//@[008:00036) |                 └─ObjectPropertyExpression
-//@[008:00030) |                   ├─StringLiteralExpression { Value = enableAutomaticUpdates }
-//@[032:00036) |                   └─BooleanLiteralExpression { Value = True }
       }
     }
   }
 }
 
 resource extension1 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:00110) ├─DeclaredResourceExpression
-//@[059:00110) | ├─ObjectExpression
   name: 'extension'
   scope: vmWithCondition
 }
 
 resource extension2 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:00105) ├─DeclaredResourceExpression
-//@[059:00105) | ├─ObjectExpression
   name: 'extension'
   scope: extension1
 }
 
 resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
-//@[000:00359) ├─DeclaredResourceExpression
-//@[065:00359) | ├─ObjectExpression
   name: 'extensionDependencies'
   properties: {
-//@[002:00255) | | └─ObjectPropertyExpression
-//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
-//@[014:00255) | |   └─ObjectExpression
     res1: vmWithCondition.id
-//@[004:00028) | |     ├─ObjectPropertyExpression
-//@[004:00008) | |     | ├─StringLiteralExpression { Value = res1 }
-//@[010:00028) | |     | └─PropertyAccessExpression { PropertyName = id }
-//@[010:00025) | |     |   └─ResourceReferenceExpression
     res1runtime: vmWithCondition.properties.something
-//@[004:00053) | |     ├─ObjectPropertyExpression
-//@[004:00015) | |     | ├─StringLiteralExpression { Value = res1runtime }
-//@[017:00053) | |     | └─AccessChainExpression
-//@[017:00043) | |     |   ├─PropertyAccessExpression { PropertyName = properties }
-//@[017:00032) | |     |   | └─ResourceReferenceExpression
-//@[044:00053) | |     |   └─StringLiteralExpression { Value = something }
     res2: extension1.id
-//@[004:00023) | |     ├─ObjectPropertyExpression
-//@[004:00008) | |     | ├─StringLiteralExpression { Value = res2 }
-//@[010:00023) | |     | └─PropertyAccessExpression { PropertyName = id }
-//@[010:00020) | |     |   └─ResourceReferenceExpression
     res2runtime: extension1.properties.something
-//@[004:00048) | |     ├─ObjectPropertyExpression
-//@[004:00015) | |     | ├─StringLiteralExpression { Value = res2runtime }
-//@[017:00048) | |     | └─AccessChainExpression
-//@[017:00038) | |     |   ├─PropertyAccessExpression { PropertyName = properties }
-//@[017:00027) | |     |   | └─ResourceReferenceExpression
-//@[039:00048) | |     |   └─StringLiteralExpression { Value = something }
     res3: extension2.id
-//@[004:00023) | |     ├─ObjectPropertyExpression
-//@[004:00008) | |     | ├─StringLiteralExpression { Value = res3 }
-//@[010:00023) | |     | └─PropertyAccessExpression { PropertyName = id }
-//@[010:00020) | |     |   └─ResourceReferenceExpression
     res3runtime: extension2.properties.something
-//@[004:00048) | |     └─ObjectPropertyExpression
-//@[004:00015) | |       ├─StringLiteralExpression { Value = res3runtime }
-//@[017:00048) | |       └─AccessChainExpression
-//@[017:00038) | |         ├─PropertyAccessExpression { PropertyName = properties }
-//@[017:00027) | |         | └─ResourceReferenceExpression
-//@[039:00048) | |         └─StringLiteralExpression { Value = something }
   }
 }
 
 @sys.description('this is existing1')
-//@[000:00162) ├─DeclaredResourceExpression
-//@[017:00036) | ├─StringLiteralExpression { Value = this is existing1 }
 resource existing1 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[077:00123) | ├─ObjectExpression
   name: 'existing1'
   scope: extension1
 }
 
 resource existing2 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[000:00122) ├─DeclaredResourceExpression
-//@[077:00122) | ├─ObjectExpression
   name: 'existing2'
   scope: existing1
 }
 
 resource extension3 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:00105) ├─DeclaredResourceExpression
-//@[059:00105) | ├─ObjectExpression
   name: 'extension3'
   scope: existing1
 }
 
 /*
   valid loop cases
-*/ 
+*/
 var storageAccounts = [
-//@[000:00129) ├─DeclaredVariableExpression { Name = storageAccounts }
-//@[022:00129) | └─ArrayExpression
   {
-//@[002:00050) |   ├─ObjectExpression
     name: 'one'
-//@[004:00015) |   | ├─ObjectPropertyExpression
-//@[004:00008) |   | | ├─StringLiteralExpression { Value = name }
-//@[010:00015) |   | | └─StringLiteralExpression { Value = one }
     location: 'eastus2'
-//@[004:00023) |   | └─ObjectPropertyExpression
-//@[004:00012) |   |   ├─StringLiteralExpression { Value = location }
-//@[014:00023) |   |   └─StringLiteralExpression { Value = eastus2 }
   }
   {
-//@[002:00049) |   └─ObjectExpression
     name: 'two'
-//@[004:00015) |     ├─ObjectPropertyExpression
-//@[004:00008) |     | ├─StringLiteralExpression { Value = name }
-//@[010:00015) |     | └─StringLiteralExpression { Value = two }
     location: 'westus'
-//@[004:00022) |     └─ObjectPropertyExpression
-//@[004:00012) |       ├─StringLiteralExpression { Value = location }
-//@[014:00022) |       └─StringLiteralExpression { Value = westus }
   }
 ]
 
 // just a storage account loop
 @sys.description('this is just a storage account loop')
-//@[000:00284) ├─DeclaredResourceExpression
-//@[017:00054) | ├─StringLiteralExpression { Value = this is just a storage account loop }
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
-//@[075:00227) | └─ForLoopExpression
-//@[091:00106) |   ├─VariableReferenceExpression { Variable = storageAccounts }
-//@[108:00226) |   └─ObjectExpression
-//@[091:00106) |     |     └─VariableReferenceExpression { Variable = storageAccounts }
   name: account.name
   location: account.location
-//@[002:00028) |     ├─ObjectPropertyExpression
-//@[002:00010) |     | ├─StringLiteralExpression { Value = location }
-//@[012:00028) |     | └─PropertyAccessExpression { PropertyName = location }
-//@[012:00019) |     |   └─ArrayAccessExpression
-//@[012:00019) |     |     ├─CopyIndexExpression
   sku: {
-//@[002:00039) |     ├─ObjectPropertyExpression
-//@[002:00005) |     | ├─StringLiteralExpression { Value = sku }
-//@[007:00039) |     | └─ObjectExpression
     name: 'Standard_LRS'
-//@[004:00024) |     |   └─ObjectPropertyExpression
-//@[004:00008) |     |     ├─StringLiteralExpression { Value = name }
-//@[010:00024) |     |     └─StringLiteralExpression { Value = Standard_LRS }
   }
   kind: 'StorageV2'
-//@[002:00019) |     └─ObjectPropertyExpression
-//@[002:00006) |       ├─StringLiteralExpression { Value = kind }
-//@[008:00019) |       └─StringLiteralExpression { Value = StorageV2 }
 }]
 
 // storage account loop with index
 @sys.description('this is just a storage account loop with index')
-//@[000:00318) ├─DeclaredResourceExpression
-//@[017:00065) | ├─StringLiteralExpression { Value = this is just a storage account loop with index }
 resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, i) in storageAccounts: {
-//@[084:00250) | └─ForLoopExpression
-//@[105:00120) |   ├─VariableReferenceExpression { Variable = storageAccounts }
-//@[122:00249) |   └─ObjectExpression
-//@[105:00120) |     |     └─VariableReferenceExpression { Variable = storageAccounts }
   name: '${account.name}${i}'
   location: account.location
-//@[002:00028) |     ├─ObjectPropertyExpression
-//@[002:00010) |     | ├─StringLiteralExpression { Value = location }
-//@[012:00028) |     | └─PropertyAccessExpression { PropertyName = location }
-//@[012:00019) |     |   └─ArrayAccessExpression
-//@[012:00019) |     |     ├─CopyIndexExpression
   sku: {
-//@[002:00039) |     ├─ObjectPropertyExpression
-//@[002:00005) |     | ├─StringLiteralExpression { Value = sku }
-//@[007:00039) |     | └─ObjectExpression
     name: 'Standard_LRS'
-//@[004:00024) |     |   └─ObjectPropertyExpression
-//@[004:00008) |     |     ├─StringLiteralExpression { Value = name }
-//@[010:00024) |     |     └─StringLiteralExpression { Value = Standard_LRS }
   }
   kind: 'StorageV2'
-//@[002:00019) |     └─ObjectPropertyExpression
-//@[002:00006) |       ├─StringLiteralExpression { Value = kind }
-//@[008:00019) |       └─StringLiteralExpression { Value = StorageV2 }
 }]
 
 // basic nested loop
 @sys.description('this is just a basic nested loop')
-//@[000:00399) ├─DeclaredResourceExpression
-//@[017:00051) | ├─StringLiteralExpression { Value = this is just a basic nested loop }
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[063:00345) | └─ForLoopExpression
-//@[073:00084) |   ├─FunctionCallExpression { Name = range }
-//@[079:00080) |   | ├─IntegerLiteralExpression { Value = 0 }
-//@[082:00083) |   | └─IntegerLiteralExpression { Value = 3 }
-//@[086:00344) |   └─ObjectExpression
-//@[073:00084) |                   | └─FunctionCallExpression { Name = range }
-//@[079:00080) |                   |   ├─IntegerLiteralExpression { Value = 0 }
-//@[082:00083) |                   |   └─IntegerLiteralExpression { Value = 3 }
   name: 'vnet-${i}'
   properties: {
-//@[002:00231) |     └─ObjectPropertyExpression
-//@[002:00012) |       ├─StringLiteralExpression { Value = properties }
-//@[014:00231) |       └─ObjectExpression
     subnets: [for j in range(0, 4): {
-//@[004:00209) |         └─ObjectPropertyExpression
-//@[004:00011) |           ├─StringLiteralExpression { Value = subnets }
-//@[013:00209) |           └─ForLoopExpression
-//@[023:00034) |             ├─FunctionCallExpression { Name = range }
-//@[029:00030) |             | ├─IntegerLiteralExpression { Value = 0 }
-//@[032:00033) |             | └─IntegerLiteralExpression { Value = 4 }
-//@[036:00208) |             └─ObjectExpression
-//@[023:00034) |                     └─FunctionCallExpression { Name = range }
-//@[029:00030) |                       ├─IntegerLiteralExpression { Value = 0 }
-//@[032:00033) |                       └─IntegerLiteralExpression { Value = 4 }
       // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
-     
+
       // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
-//@[006:00030) |               └─ObjectPropertyExpression
-//@[006:00010) |                 ├─StringLiteralExpression { Value = name }
-//@[012:00030) |                 └─InterpolatedStringExpression
-//@[022:00023) |                   ├─ArrayAccessExpression
-//@[022:00023) |                   | ├─CopyIndexExpression
-//@[027:00028) |                   └─ArrayAccessExpression
-//@[027:00028) |                     ├─CopyIndexExpression
     }]
   }
 }]
 
 // duplicate identifiers within the loop are allowed
 resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[000:00239) ├─DeclaredResourceExpression
-//@[089:00239) | └─ForLoopExpression
-//@[099:00110) |   ├─FunctionCallExpression { Name = range }
-//@[105:00106) |   | ├─IntegerLiteralExpression { Value = 0 }
-//@[108:00109) |   | └─IntegerLiteralExpression { Value = 3 }
-//@[112:00238) |   └─ObjectExpression
   name: 'vnet-${i}'
   properties: {
-//@[002:00099) |     └─ObjectPropertyExpression
-//@[002:00012) |       ├─StringLiteralExpression { Value = properties }
-//@[014:00099) |       └─ObjectExpression
     subnets: [for i in range(0, 4): {
-//@[004:00077) |         └─ObjectPropertyExpression
-//@[004:00011) |           ├─StringLiteralExpression { Value = subnets }
-//@[013:00077) |           └─ForLoopExpression
-//@[023:00034) |             ├─FunctionCallExpression { Name = range }
-//@[029:00030) |             | ├─IntegerLiteralExpression { Value = 0 }
-//@[032:00033) |             | └─IntegerLiteralExpression { Value = 4 }
-//@[036:00076) |             └─ObjectExpression
-//@[023:00034) |                   | └─FunctionCallExpression { Name = range }
-//@[029:00030) |                   |   ├─IntegerLiteralExpression { Value = 0 }
-//@[032:00033) |                   |   └─IntegerLiteralExpression { Value = 4 }
-//@[023:00034) |                     └─FunctionCallExpression { Name = range }
-//@[029:00030) |                       ├─IntegerLiteralExpression { Value = 0 }
-//@[032:00033) |                       └─IntegerLiteralExpression { Value = 4 }
       name: 'subnet-${i}-${i}'
-//@[006:00030) |               └─ObjectPropertyExpression
-//@[006:00010) |                 ├─StringLiteralExpression { Value = name }
-//@[012:00030) |                 └─InterpolatedStringExpression
-//@[022:00023) |                   ├─ArrayAccessExpression
-//@[022:00023) |                   | ├─CopyIndexExpression
-//@[027:00028) |                   └─ArrayAccessExpression
-//@[027:00028) |                     ├─CopyIndexExpression
     }]
   }
 }]
 
 // duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
 var canHaveDuplicatesAcrossScopes = 'hello'
-//@[000:00043) ├─DeclaredVariableExpression { Name = canHaveDuplicatesAcrossScopes }
-//@[036:00043) | └─StringLiteralExpression { Value = hello }
 resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
-//@[000:00292) ├─DeclaredResourceExpression
-//@[086:00292) | └─ForLoopExpression
-//@[124:00135) |   ├─FunctionCallExpression { Name = range }
-//@[130:00131) |   | ├─IntegerLiteralExpression { Value = 0 }
-//@[133:00134) |   | └─IntegerLiteralExpression { Value = 3 }
-//@[137:00291) |   └─ObjectExpression
   name: 'vnet-${canHaveDuplicatesAcrossScopes}'
   properties: {
-//@[002:00099) |     └─ObjectPropertyExpression
-//@[002:00012) |       ├─StringLiteralExpression { Value = properties }
-//@[014:00099) |       └─ObjectExpression
     subnets: [for i in range(0, 4): {
-//@[004:00077) |         └─ObjectPropertyExpression
-//@[004:00011) |           ├─StringLiteralExpression { Value = subnets }
-//@[013:00077) |           └─ForLoopExpression
-//@[023:00034) |             ├─FunctionCallExpression { Name = range }
-//@[029:00030) |             | ├─IntegerLiteralExpression { Value = 0 }
-//@[032:00033) |             | └─IntegerLiteralExpression { Value = 4 }
-//@[036:00076) |             └─ObjectExpression
-//@[023:00034) |                   | └─FunctionCallExpression { Name = range }
-//@[029:00030) |                   |   ├─IntegerLiteralExpression { Value = 0 }
-//@[032:00033) |                   |   └─IntegerLiteralExpression { Value = 4 }
-//@[023:00034) |                     └─FunctionCallExpression { Name = range }
-//@[029:00030) |                       ├─IntegerLiteralExpression { Value = 0 }
-//@[032:00033) |                       └─IntegerLiteralExpression { Value = 4 }
       name: 'subnet-${i}-${i}'
-//@[006:00030) |               └─ObjectPropertyExpression
-//@[006:00010) |                 ├─StringLiteralExpression { Value = name }
-//@[012:00030) |                 └─InterpolatedStringExpression
-//@[022:00023) |                   ├─ArrayAccessExpression
-//@[022:00023) |                   | ├─CopyIndexExpression
-//@[027:00028) |                   └─ArrayAccessExpression
-//@[027:00028) |                     ├─CopyIndexExpression
     }]
   }
 }]
 
 // duplicate in global and multiple loop scopes are allowed (inner hides the outer)
 var duplicatesEverywhere = 'hello'
-//@[000:00034) ├─DeclaredVariableExpression { Name = duplicatesEverywhere }
-//@[027:00034) | └─StringLiteralExpression { Value = hello }
 resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
-//@[000:00308) ├─DeclaredResourceExpression
-//@[087:00308) | └─ForLoopExpression
-//@[116:00127) |   ├─FunctionCallExpression { Name = range }
-//@[122:00123) |   | ├─IntegerLiteralExpression { Value = 0 }
-//@[125:00126) |   | └─IntegerLiteralExpression { Value = 3 }
-//@[129:00307) |   └─ObjectExpression
   name: 'vnet-${duplicatesEverywhere}'
   properties: {
-//@[002:00132) |     └─ObjectPropertyExpression
-//@[002:00012) |       ├─StringLiteralExpression { Value = properties }
-//@[014:00132) |       └─ObjectExpression
     subnets: [for duplicatesEverywhere in range(0, 4): {
-//@[004:00110) |         └─ObjectPropertyExpression
-//@[004:00011) |           ├─StringLiteralExpression { Value = subnets }
-//@[013:00110) |           └─ForLoopExpression
-//@[042:00053) |             ├─FunctionCallExpression { Name = range }
-//@[048:00049) |             | ├─IntegerLiteralExpression { Value = 0 }
-//@[051:00052) |             | └─IntegerLiteralExpression { Value = 4 }
-//@[055:00109) |             └─ObjectExpression
-//@[042:00053) |                     └─FunctionCallExpression { Name = range }
-//@[048:00049) |                       ├─IntegerLiteralExpression { Value = 0 }
-//@[051:00052) |                       └─IntegerLiteralExpression { Value = 4 }
       name: 'subnet-${duplicatesEverywhere}'
-//@[006:00044) |               └─ObjectPropertyExpression
-//@[006:00010) |                 ├─StringLiteralExpression { Value = name }
-//@[012:00044) |                 └─InterpolatedStringExpression
-//@[022:00042) |                   └─ArrayAccessExpression
-//@[022:00042) |                     ├─CopyIndexExpression
     }]
   }
 }]
@@ -1060,341 +375,148 @@ resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06
   Scope values created via array access on a resource collection
 */
 resource dnsZones 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in range(0,4): {
-//@[000:00135) ├─DeclaredResourceExpression
-//@[060:00135) | └─ForLoopExpression
-//@[073:00083) |   ├─FunctionCallExpression { Name = range }
-//@[079:00080) |   | ├─IntegerLiteralExpression { Value = 0 }
-//@[081:00082) |   | └─IntegerLiteralExpression { Value = 4 }
-//@[085:00134) |   └─ObjectExpression
   name: 'zone${zone}'
   location: 'global'
-//@[002:00020) |     └─ObjectPropertyExpression
-//@[002:00010) |       ├─StringLiteralExpression { Value = location }
-//@[012:00020) |       └─StringLiteralExpression { Value = global }
 }]
 
 resource locksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for lock in range(0,2): {
-//@[000:00194) ├─DeclaredResourceExpression
-//@[067:00194) | ├─ForLoopExpression
-//@[080:00090) | | ├─FunctionCallExpression { Name = range }
-//@[086:00087) | | | ├─IntegerLiteralExpression { Value = 0 }
-//@[088:00089) | | | └─IntegerLiteralExpression { Value = 2 }
-//@[092:00193) | | └─ObjectExpression
   name: 'lock${lock}'
   properties: {
-//@[002:00047) | |   └─ObjectPropertyExpression
-//@[002:00012) | |     ├─StringLiteralExpression { Value = properties }
-//@[014:00047) | |     └─ObjectExpression
     level: 'CanNotDelete'
-//@[004:00025) | |       └─ObjectPropertyExpression
-//@[004:00009) | |         ├─StringLiteralExpression { Value = level }
-//@[011:00025) | |         └─StringLiteralExpression { Value = CanNotDelete }
   }
   scope: dnsZones[lock]
 }]
 
 resource moreLocksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for (lock, i) in range(0,3): {
-//@[000:00196) ├─DeclaredResourceExpression
-//@[071:00196) | ├─ForLoopExpression
-//@[089:00099) | | ├─FunctionCallExpression { Name = range }
-//@[095:00096) | | | ├─IntegerLiteralExpression { Value = 0 }
-//@[097:00098) | | | └─IntegerLiteralExpression { Value = 3 }
-//@[101:00195) | | └─ObjectExpression
   name: 'another${i}'
   properties: {
-//@[002:00043) | |   └─ObjectPropertyExpression
-//@[002:00012) | |     ├─StringLiteralExpression { Value = properties }
-//@[014:00043) | |     └─ObjectExpression
     level: 'ReadOnly'
-//@[004:00021) | |       └─ObjectPropertyExpression
-//@[004:00009) | |         ├─StringLiteralExpression { Value = level }
-//@[011:00021) | |         └─StringLiteralExpression { Value = ReadOnly }
   }
   scope: dnsZones[i]
 }]
 
 resource singleLockOnFirstZone 'Microsoft.Authorization/locks@2016-09-01' = {
-//@[000:00170) ├─DeclaredResourceExpression
-//@[076:00170) | ├─ObjectExpression
   name: 'single-lock'
   properties: {
-//@[002:00043) | | └─ObjectPropertyExpression
-//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
-//@[014:00043) | |   └─ObjectExpression
     level: 'ReadOnly'
-//@[004:00021) | |     └─ObjectPropertyExpression
-//@[004:00009) | |       ├─StringLiteralExpression { Value = level }
-//@[011:00021) | |       └─StringLiteralExpression { Value = ReadOnly }
   }
   scope: dnsZones[0]
 }
 
 
 resource p1_vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@[000:00234) ├─DeclaredResourceExpression
-//@[066:00234) | └─ObjectExpression
   location: resourceGroup().location
-//@[002:00036) |   ├─ObjectPropertyExpression
-//@[002:00010) |   | ├─StringLiteralExpression { Value = location }
-//@[012:00036) |   | └─PropertyAccessExpression { PropertyName = location }
-//@[012:00027) |   |   └─FunctionCallExpression { Name = resourceGroup }
   name: 'myVnet'
   properties: {
-//@[002:00106) |   └─ObjectPropertyExpression
-//@[002:00012) |     ├─StringLiteralExpression { Value = properties }
-//@[014:00106) |     └─ObjectExpression
     addressSpace: {
-//@[004:00084) |       └─ObjectPropertyExpression
-//@[004:00016) |         ├─StringLiteralExpression { Value = addressSpace }
-//@[018:00084) |         └─ObjectExpression
       addressPrefixes: [
-//@[006:00056) |           └─ObjectPropertyExpression
-//@[006:00021) |             ├─StringLiteralExpression { Value = addressPrefixes }
-//@[023:00056) |             └─ArrayExpression
         '10.0.0.0/20'
-//@[008:00021) |               └─StringLiteralExpression { Value = 10.0.0.0/20 }
       ]
     }
   }
 }
 
 resource p1_subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@[000:00175) ├─DeclaredResourceExpression
-//@[077:00175) | ├─ObjectExpression
   parent: p1_vnet
   name: 'subnet1'
   properties: {
-//@[002:00054) | | └─ObjectPropertyExpression
-//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
-//@[014:00054) | |   └─ObjectExpression
     addressPrefix: '10.0.0.0/24'
-//@[004:00032) | |     └─ObjectPropertyExpression
-//@[004:00017) | |       ├─StringLiteralExpression { Value = addressPrefix }
-//@[019:00032) | |       └─StringLiteralExpression { Value = 10.0.0.0/24 }
   }
 }
 
 resource p1_subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@[000:00175) ├─DeclaredResourceExpression
-//@[077:00175) | ├─ObjectExpression
   parent: p1_vnet
   name: 'subnet2'
   properties: {
-//@[002:00054) | | └─ObjectPropertyExpression
-//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
-//@[014:00054) | |   └─ObjectExpression
     addressPrefix: '10.0.1.0/24'
-//@[004:00032) | |     └─ObjectPropertyExpression
-//@[004:00017) | |       ├─StringLiteralExpression { Value = addressPrefix }
-//@[019:00032) | |       └─StringLiteralExpression { Value = 10.0.1.0/24 }
   }
 }
 
 output p1_subnet1prefix string = p1_subnet1.properties.addressPrefix
-//@[000:00068) ├─DeclaredOutputExpression { Name = p1_subnet1prefix }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00068) | └─AccessChainExpression
-//@[033:00054) |   ├─PropertyAccessExpression { PropertyName = properties }
-//@[033:00043) |   | └─ResourceReferenceExpression
-//@[055:00068) |   └─StringLiteralExpression { Value = addressPrefix }
 output p1_subnet1name string = p1_subnet1.name
-//@[000:00046) ├─DeclaredOutputExpression { Name = p1_subnet1name }
-//@[022:00028) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[031:00046) | └─PropertyAccessExpression { PropertyName = name }
-//@[031:00041) |   └─ResourceReferenceExpression
 output p1_subnet1type string = p1_subnet1.type
-//@[000:00046) ├─DeclaredOutputExpression { Name = p1_subnet1type }
-//@[022:00028) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[031:00046) | └─PropertyAccessExpression { PropertyName = type }
-//@[031:00041) |   └─ResourceReferenceExpression
 output p1_subnet1id string = p1_subnet1.id
-//@[000:00042) ├─DeclaredOutputExpression { Name = p1_subnet1id }
-//@[020:00026) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[029:00042) | └─PropertyAccessExpression { PropertyName = id }
-//@[029:00039) |   └─ResourceReferenceExpression
 
 // parent property with extension resource
 resource p2_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
-//@[000:00076) ├─DeclaredResourceExpression
-//@[056:00076) | └─ObjectExpression
   name: 'res1'
 }
 
 resource p2_res1child 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[000:00109) ├─DeclaredResourceExpression
-//@[068:00109) | ├─ObjectExpression
   parent: p2_res1
   name: 'child1'
 }
 
 resource p2_res2 'Microsoft.Rp2/resource2@2020-06-01' = {
-//@[000:00099) ├─DeclaredResourceExpression
-//@[056:00099) | ├─ObjectExpression
   scope: p2_res1child
   name: 'res2'
 }
 
 resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
-//@[000:00109) ├─DeclaredResourceExpression
-//@[068:00109) | ├─ObjectExpression
   parent: p2_res2
   name: 'child2'
 }
 
 output p2_res2childprop string = p2_res2child.properties.someProp
-//@[000:00065) ├─DeclaredOutputExpression { Name = p2_res2childprop }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00065) | └─AccessChainExpression
-//@[033:00056) |   ├─PropertyAccessExpression { PropertyName = properties }
-//@[033:00045) |   | └─ResourceReferenceExpression
-//@[057:00065) |   └─StringLiteralExpression { Value = someProp }
 output p2_res2childname string = p2_res2child.name
-//@[000:00050) ├─DeclaredOutputExpression { Name = p2_res2childname }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00050) | └─PropertyAccessExpression { PropertyName = name }
-//@[033:00045) |   └─ResourceReferenceExpression
 output p2_res2childtype string = p2_res2child.type
-//@[000:00050) ├─DeclaredOutputExpression { Name = p2_res2childtype }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00050) | └─PropertyAccessExpression { PropertyName = type }
-//@[033:00045) |   └─ResourceReferenceExpression
 output p2_res2childid string = p2_res2child.id
-//@[000:00046) ├─DeclaredOutputExpression { Name = p2_res2childid }
-//@[022:00028) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[031:00046) | └─PropertyAccessExpression { PropertyName = id }
-//@[031:00043) |   └─ResourceReferenceExpression
 
 // parent property with 'existing' resource
 resource p3_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[000:00085) ├─DeclaredResourceExpression
-//@[065:00085) | └─ObjectExpression
   name: 'res1'
 }
 
 resource p3_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[000:00106) ├─DeclaredResourceExpression
-//@[065:00106) | └─ObjectExpression
   parent: p3_res1
   name: 'child1'
 }
 
 output p3_res1childprop string = p3_child1.properties.someProp
-//@[000:00062) ├─DeclaredOutputExpression { Name = p3_res1childprop }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00062) | └─AccessChainExpression
-//@[033:00053) |   ├─PropertyAccessExpression { PropertyName = properties }
-//@[033:00042) |   | └─ResourceReferenceExpression
-//@[054:00062) |   └─StringLiteralExpression { Value = someProp }
 output p3_res1childname string = p3_child1.name
-//@[000:00047) ├─DeclaredOutputExpression { Name = p3_res1childname }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00047) | └─PropertyAccessExpression { PropertyName = name }
-//@[033:00042) |   └─ResourceReferenceExpression
 output p3_res1childtype string = p3_child1.type
-//@[000:00047) ├─DeclaredOutputExpression { Name = p3_res1childtype }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00047) | └─PropertyAccessExpression { PropertyName = type }
-//@[033:00042) |   └─ResourceReferenceExpression
 output p3_res1childid string = p3_child1.id
-//@[000:00043) ├─DeclaredOutputExpression { Name = p3_res1childid }
-//@[022:00028) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[031:00043) | └─PropertyAccessExpression { PropertyName = id }
-//@[031:00040) |   └─ResourceReferenceExpression
 
 // parent & child with 'existing'
 resource p4_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[000:00104) ├─DeclaredResourceExpression
-//@[065:00104) | └─ObjectExpression
   scope: tenant()
   name: 'res1'
 }
 
 resource p4_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' existing = {
-//@[000:00115) ├─DeclaredResourceExpression
-//@[074:00115) | └─ObjectExpression
   parent: p4_res1
   name: 'child1'
 }
 
 output p4_res1childprop string = p4_child1.properties.someProp
-//@[000:00062) ├─DeclaredOutputExpression { Name = p4_res1childprop }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00062) | └─AccessChainExpression
-//@[033:00053) |   ├─PropertyAccessExpression { PropertyName = properties }
-//@[033:00042) |   | └─ResourceReferenceExpression
-//@[054:00062) |   └─StringLiteralExpression { Value = someProp }
 output p4_res1childname string = p4_child1.name
-//@[000:00047) ├─DeclaredOutputExpression { Name = p4_res1childname }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00047) | └─PropertyAccessExpression { PropertyName = name }
-//@[033:00042) |   └─ResourceReferenceExpression
 output p4_res1childtype string = p4_child1.type
-//@[000:00047) ├─DeclaredOutputExpression { Name = p4_res1childtype }
-//@[024:00030) | ├─AmbientTypeReferenceExpression { Name = string }
-//@[033:00047) | └─PropertyAccessExpression { PropertyName = type }
-//@[033:00042) |   └─ResourceReferenceExpression
 output p4_res1childid string = p4_child1.id
-//@[000:00043) └─DeclaredOutputExpression { Name = p4_res1childid }
-//@[022:00028)   ├─AmbientTypeReferenceExpression { Name = string }
-//@[031:00043)   └─PropertyAccessExpression { PropertyName = id }
-//@[031:00040)     └─ResourceReferenceExpression
 
 // parent & nested child with decorators https://github.com/Azure/bicep/issues/10970
 var dbs = ['db1', 'db2','db3']
-//@[000:00030) ├─DeclaredVariableExpression { Name = dbs }
-//@[010:00030) | └─ArrayExpression
-//@[011:00016) |   ├─StringLiteralExpression { Value = db1 }
-//@[018:00023) |   ├─StringLiteralExpression { Value = db2 }
-//@[024:00029) |   └─StringLiteralExpression { Value = db3 }
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
-//@[000:00572) ├─DeclaredResourceExpression
-//@[056:00572) | └─ObjectExpression
   name: 'sql-server-name'
   location: 'polandcentral'
-//@[002:00027) |   └─ObjectPropertyExpression
-//@[002:00010) |     ├─StringLiteralExpression { Value = location }
-//@[012:00027) |     └─StringLiteralExpression { Value = polandcentral }
 
   @batchSize(1)
-//@[002:00156) ├─DeclaredResourceExpression
   @description('Sql Databases')
-//@[015:00030) | ├─StringLiteralExpression { Value = Sql Databases }
   resource sqlDatabases 'databases' = [for db in dbs: {
-//@[038:00106) | ├─ForLoopExpression
-//@[049:00052) | | ├─VariableReferenceExpression { Variable = dbs }
-//@[054:00105) | | └─ObjectExpression
     name: db
     location: 'polandcentral'
-//@[004:00029) | |   └─ObjectPropertyExpression
-//@[004:00012) | |     ├─StringLiteralExpression { Value = location }
-//@[014:00029) | |     └─StringLiteralExpression { Value = polandcentral }
   }]
 
   @description('Primary Sql Database')
-//@[002:00292) ├─DeclaredResourceExpression
-//@[015:00037) | ├─StringLiteralExpression { Value = Primary Sql Database }
   resource primaryDb 'databases' = {
-//@[035:00252) | ├─ObjectExpression
     name: 'primary-db'
     location: 'polandcentral'
 
     resource threatProtection 'advancedThreatProtectionSettings' = {
-//@[004:00029) | | └─ObjectPropertyExpression
-//@[004:00012) | |   ├─StringLiteralExpression { Value = location }
-//@[014:00029) | |   └─StringLiteralExpression { Value = polandcentral }
       name: 'Default'
       properties: {
-//@[004:00154) ├─DeclaredResourceExpression
-//@[067:00154) | ├─ObjectExpression
         state: 'Enabled'
       }
-//@[006:00054) | | └─ObjectPropertyExpression
-//@[006:00016) | |   ├─StringLiteralExpression { Value = properties }
-//@[018:00054) | |   └─ObjectExpression
     }
-//@[008:00024) | |     └─ObjectPropertyExpression
-//@[008:00013) | |       ├─StringLiteralExpression { Value = state }
-//@[015:00024) | |       └─StringLiteralExpression { Value = Enabled }
   }
 }
 
@@ -1407,13 +529,66 @@ var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
 
 var sqlConfig = {
   westus: {}
-  server: {}
-  'my-rg': {}
+  'server-name': {}
 }
 
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
-  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
   location: nameof(sqlConfig.westus)
-  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }
 
+//@[000:13471) ProgramExpression
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9175006065683431096"
+      "templateHash": "2858757969212984934"
     }
   },
   "parameters": {
@@ -57,9 +57,29 @@
       "db1",
       "db2",
       "db3"
-    ]
+    ],
+    "nameof1": "sqlServer",
+    "nameof2": "location",
+    "nameof3": "minCapacity",
+    "nameof4": "creationTime",
+    "nameof5": "id",
+    "sqlConfig": {
+      "westus": {},
+      "server-name": {}
+    }
   },
   "resources": [
+    {
+      "type": "Microsoft.Sql/servers/databases/advancedThreatProtectionSettings",
+      "apiVersion": "2021-11-01",
+      "name": "[format('{0}/{1}/{2}', 'sql-server-name', 'primary-db', 'Default')]",
+      "properties": {
+        "state": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers/databases', 'sql-server-name', 'primary-db')]"
+      ]
+    },
     {
       "copy": {
         "name": "sqlDatabases",
@@ -629,6 +649,12 @@
       "apiVersion": "2021-11-01",
       "name": "sql-server-name",
       "location": "polandcentral"
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-11-01",
+      "name": "[format('sql-server-nameof-{0}', '''server-name''')]",
+      "location": "westus"
     }
   ],
   "outputs": {

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.sourcemap.bicep
@@ -1,140 +1,65 @@
 
 @sys.description('this is basicStorage')
-//@        "description": "this is basicStorage"
 resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@    {
-//@      "type": "Microsoft.Storage/storageAccounts",
-//@      "apiVersion": "2019-06-01",
-//@      "name": "basicblobs",
-//@      "metadata": {
-//@      }
-//@    },
   name: 'basicblobs'
   location: 'westus'
-//@      "location": "westus",
   kind: 'BlobStorage'
-//@      "kind": "BlobStorage",
   sku: {
-//@      "sku": {
-//@      },
     name: 'Standard_GRS'
-//@        "name": "Standard_GRS"
   }
 }
 
 @sys.description('this is dnsZone')
-//@        "description": "this is dnsZone"
 resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
-//@    {
-//@      "type": "Microsoft.Network/dnsZones",
-//@      "apiVersion": "2018-05-01",
-//@      "name": "myZone",
-//@      "metadata": {
-//@      }
-//@    },
   name: 'myZone'
   location: 'global'
-//@      "location": "global",
 }
 
 resource myStorageAccount 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@    {
-//@      "type": "Microsoft.Storage/storageAccounts",
-//@      "apiVersion": "2017-10-01",
-//@      "name": "myencryptedone",
-//@    },
   name: 'myencryptedone'
   location: 'eastus2'
-//@      "location": "eastus2",
   properties: {
-//@      "properties": {
-//@      },
     supportsHttpsTrafficOnly: true
-//@        "supportsHttpsTrafficOnly": true,
     accessTier: 'Hot'
-//@        "accessTier": "Hot",
     encryption: {
-//@        "encryption": {
-//@        }
       keySource: 'Microsoft.Storage'
-//@          "keySource": "Microsoft.Storage",
       services: {
-//@          "services": {
-//@          }
         blob: {
-//@            "blob": {
-//@            },
           enabled: true
-//@              "enabled": true
         }
         file: {
-//@            "file": {
-//@            }
           enabled: true
-//@              "enabled": true
         }
       }
     }
   }
   kind: 'StorageV2'
-//@      "kind": "StorageV2",
   sku: {
-//@      "sku": {
-//@      }
     name: 'Standard_LRS'
-//@        "name": "Standard_LRS"
   }
 }
 
 resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@    {
-//@      "type": "Microsoft.Storage/storageAccounts",
-//@      "apiVersion": "2017-10-01",
-//@      "name": "myencryptedone2",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Storage/storageAccounts', 'myencryptedone')]"
-//@      ]
-//@    },
   name: 'myencryptedone2'
   location: 'eastus2'
-//@      "location": "eastus2",
   properties: {
-//@      "properties": {
-//@      },
     supportsHttpsTrafficOnly: !false
-//@        "supportsHttpsTrafficOnly": "[not(false())]",
     accessTier: true ? 'Hot' : 'Cold'
-//@        "accessTier": "[if(true(), 'Hot', 'Cold')]",
     encryption: {
-//@        "encryption": {
-//@        }
       keySource: 'Microsoft.Storage'
-//@          "keySource": "Microsoft.Storage",
       services: {
-//@          "services": {
-//@          }
         blob: {
-//@            "blob": {
-//@            },
           enabled: true || false
-//@              "enabled": "[or(true(), false())]"
         }
         file: {
-//@            "file": {
-//@            }
           enabled: true
-//@              "enabled": true
         }
       }
     }
   }
   kind: 'StorageV2'
-//@      "kind": "StorageV2",
   sku: {
-//@      "sku": {
-//@      },
     name: 'Standard_LRS'
-//@        "name": "Standard_LRS"
   }
   dependsOn: [
     myStorageAccount
@@ -142,53 +67,27 @@ resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
 }
 
 param applicationName string = 'to-do-app${uniqueString(resourceGroup().id)}'
-//@    "applicationName": {
-//@      "type": "string",
-//@      "defaultValue": "[format('to-do-app{0}', uniqueString(resourceGroup().id))]"
-//@    },
 var hostingPlanName = applicationName // why not just use the param directly?
-//@    "hostingPlanName": "[parameters('applicationName')]",
 
 param appServicePlanTier string
-//@    "appServicePlanTier": {
-//@      "type": "string"
-//@    },
 param appServicePlanInstances int
-//@    "appServicePlanInstances": {
-//@      "type": "int"
-//@    },
 
 var location = resourceGroup().location
-//@    "location": "[resourceGroup().location]",
 
 resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
-//@    {
-//@      "type": "Microsoft.Web/serverfarms",
-//@      "apiVersion": "2019-08-01",
-//@      "name": "[variables('hostingPlanName')]",
-//@    },
   // dependsOn: resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosAccountName)
   name: hostingPlanName
   location: location
-//@      "location": "[variables('location')]",
   sku: {
-//@      "sku": {
-//@      },
     name: appServicePlanTier
-//@        "name": "[parameters('appServicePlanTier')]",
     capacity: appServicePlanInstances
-//@        "capacity": "[parameters('appServicePlanInstances')]"
   }
   properties: {
-//@      "properties": {
-//@      }
     name: hostingPlanName // just hostingPlanName results in an error
-//@        "name": "[variables('hostingPlanName')]"
   }
 }
 
 var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
-//@    "cosmosDbResourceId": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDb').account)]",
 // comment
 cosmosDb.account)
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
@@ -198,63 +97,29 @@ var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 var cosmosDbEndpoint = cosmosDbRef.documentEndpoint
 
 param webSiteName string
-//@    "webSiteName": {
-//@      "type": "string"
-//@    },
 param cosmosDb object
-//@    "cosmosDb": {
-//@      "type": "object"
-//@    },
 resource site 'Microsoft.Web/sites@2019-08-01' = {
-//@    {
-//@      "type": "Microsoft.Web/sites",
-//@      "apiVersion": "2019-08-01",
-//@      "name": "[parameters('webSiteName')]",
-//@    },
   name: webSiteName
   location: location
-//@      "location": "[variables('location')]",
   properties: {
-//@      "properties": {
-//@      }
     // not yet supported // serverFarmId: farm.id
     siteConfig: {
-//@        "siteConfig": {
-//@        }
       appSettings: [
-//@          "appSettings": [
-//@          ]
         {
-//@            {
-//@            },
           name: 'CosmosDb:Account'
-//@              "name": "CosmosDb:Account",
           value: reference(cosmosDbResourceId).documentEndpoint
-//@              "value": "[reference(variables('cosmosDbResourceId')).documentEndpoint]"
         }
         {
-//@            {
-//@            },
           name: 'CosmosDb:Key'
-//@              "name": "CosmosDb:Key",
           value: listKeys(cosmosDbResourceId, '2020-04-01').primaryMasterKey
-//@              "value": "[listKeys(variables('cosmosDbResourceId'), '2020-04-01').primaryMasterKey]"
         }
         {
-//@            {
-//@            },
           name: 'CosmosDb:DatabaseName'
-//@              "name": "CosmosDb:DatabaseName",
           value: cosmosDb.databaseName
-//@              "value": "[parameters('cosmosDb').databaseName]"
         }
         {
-//@            {
-//@            }
           name: 'CosmosDb:ContainerName'
-//@              "name": "CosmosDb:ContainerName",
           value: cosmosDb.containerName
-//@              "value": "[parameters('cosmosDb').containerName]"
         }
       ]
     }
@@ -262,43 +127,20 @@ resource site 'Microsoft.Web/sites@2019-08-01' = {
 }
 
 var _siteApiVersion = site.apiVersion
-//@    "_siteApiVersion": "2019-08-01",
 var _siteType = site.type
-//@    "_siteType": "Microsoft.Web/sites",
 
 output siteApiVersion string = site.apiVersion
-//@    "siteApiVersion": {
-//@      "type": "string",
-//@      "value": "2019-08-01"
-//@    },
 output siteType string = site.type
-//@    "siteType": {
-//@      "type": "string",
-//@      "value": "Microsoft.Web/sites"
-//@    },
 
 resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
-//@    {
-//@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2019-10-01",
-//@      "name": "nestedTemplate1",
-//@    },
   name: 'nestedTemplate1'
   properties: {
-//@      "properties": {
-//@      }
     mode: 'Incremental'
-//@        "mode": "Incremental",
     template: {
-//@        "template": {
-//@        }
       // string key value
       '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-//@          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       contentVersion: '1.0.0.0'
-//@          "contentVersion": "1.0.0.0",
       resources: [
-//@          "resources": []
       ]
     }
   }
@@ -306,291 +148,128 @@ resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
 
 // should be able to access the read only properties
 resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
-//@    {
-//@      "type": "Microsoft.Foo/foos",
-//@      "apiVersion": "2019-10-01",
-//@      "name": "nestedTemplate1",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Resources/deployments', 'nestedTemplate1')]"
-//@      ]
-//@    },
   name: 'nestedTemplate1'
   properties: {
-//@      "properties": {
-//@      },
     otherId: nested.id
-//@        "otherId": "[resourceId('Microsoft.Resources/deployments', 'nestedTemplate1')]",
     otherName: nested.name
-//@        "otherName": "nestedTemplate1",
     otherVersion: nested.apiVersion
-//@        "otherVersion": "2019-10-01",
     otherType: nested.type
-//@        "otherType": "Microsoft.Resources/deployments",
 
     otherThings: nested.properties.mode
-//@        "otherThings": "[reference(resourceId('Microsoft.Resources/deployments', 'nestedTemplate1'), '2019-10-01').mode]"
   }
 }
 
 resource resourceA 'My.Rp/typeA@2020-01-01' = {
-//@    {
-//@      "type": "My.Rp/typeA",
-//@      "apiVersion": "2020-01-01",
-//@      "name": "resourceA"
-//@    },
   name: 'resourceA'
 }
 
 resource resourceB 'My.Rp/typeA/typeB@2020-01-01' = {
-//@    {
-//@      "type": "My.Rp/typeA/typeB",
-//@      "apiVersion": "2020-01-01",
-//@      "name": "[format('{0}/myName', 'resourceA')]",
-//@      "dependsOn": [
-//@        "[resourceId('My.Rp/typeA', 'resourceA')]"
-//@      ]
-//@    },
   name: '${resourceA.name}/myName'
 }
 
 resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
-//@    {
-//@      "type": "My.Rp/typeA/typeB",
-//@      "apiVersion": "2020-01-01",
-//@      "name": "[format('{0}/myName', 'resourceA')]",
-//@      "dependsOn": [
-//@        "[resourceId('My.Rp/typeA', 'resourceA')]",
-//@        "[resourceId('My.Rp/typeA/typeB', split(format('{0}/myName', 'resourceA'), '/')[0], split(format('{0}/myName', 'resourceA'), '/')[1])]"
-//@      ]
-//@    },
   name: '${resourceA.name}/myName'
   properties: {
-//@      "properties": {
-//@      },
     aId: resourceA.id
-//@        "aId": "[resourceId('My.Rp/typeA', 'resourceA')]",
     aType: resourceA.type
-//@        "aType": "My.Rp/typeA",
     aName: resourceA.name
-//@        "aName": "resourceA",
     aApiVersion: resourceA.apiVersion
-//@        "aApiVersion": "2020-01-01",
     bProperties: resourceB.properties
-//@        "bProperties": "[reference(resourceId('My.Rp/typeA/typeB', split(format('{0}/myName', 'resourceA'), '/')[0], split(format('{0}/myName', 'resourceA'), '/')[1]), '2020-01-01')]"
   }
 }
 
 var varARuntime = {
-//@          {
-//@          }
   bId: resourceB.id
-//@            "bId": "[resourceId('My.Rp/typeA/typeB', split(format('{0}/myName', 'resourceA'), '/')[0], split(format('{0}/myName', 'resourceA'), '/')[1])]",
   bType: resourceB.type
-//@            "bType": "My.Rp/typeA/typeB",
   bName: resourceB.name
-//@            "bName": "[format('{0}/myName', 'resourceA')]",
   bApiVersion: resourceB.apiVersion
-//@            "bApiVersion": "2020-01-01",
   aKind: resourceA.kind
-//@            "aKind": "[reference(resourceId('My.Rp/typeA', 'resourceA'), '2020-01-01', 'full').kind]"
 }
 
 var varBRuntime = [
-//@        "runtime": [
-//@        ],
   varARuntime
 ]
 
 var resourceCRef = {
-//@    "resourceCRef": {
-//@    },
   id: resourceC.id
-//@      "id": "[resourceId('My.Rp/typeA/typeB', split(format('{0}/myName', 'resourceA'), '/')[0], split(format('{0}/myName', 'resourceA'), '/')[1])]"
 }
 var setResourceCRef = true
-//@    "setResourceCRef": true,
 
 resource resourceD 'My.Rp/typeD@2020-01-01' = {
-//@    {
-//@      "type": "My.Rp/typeD",
-//@      "apiVersion": "2020-01-01",
-//@      "name": "constant",
-//@      "dependsOn": [
-//@        "[resourceId('My.Rp/typeA', 'resourceA')]",
-//@        "[resourceId('My.Rp/typeA/typeB', split(format('{0}/myName', 'resourceA'), '/')[0], split(format('{0}/myName', 'resourceA'), '/')[1])]",
-//@        "[resourceId('My.Rp/typeA/typeB', split(format('{0}/myName', 'resourceA'), '/')[0], split(format('{0}/myName', 'resourceA'), '/')[1])]"
-//@      ]
-//@    },
   name: 'constant'
   properties: {
-//@      "properties": {
-//@      },
     runtime: varBRuntime
     // repro for https://github.com/Azure/bicep/issues/316
     repro316: setResourceCRef ? resourceCRef : null
-//@        "repro316": "[if(variables('setResourceCRef'), variables('resourceCRef'), null())]"
   }
 }
 
 var myInterpKey = 'abc'
-//@    "myInterpKey": "abc",
 resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
-//@    {
-//@      "type": "My.Rp/interp",
-//@      "apiVersion": "2020-01-01",
-//@      "name": "interpTest",
-//@    },
   name: 'interpTest'
   properties: {
-//@      "properties": {
-//@      }
     '${myInterpKey}': 1
-//@        "[format('{0}', variables('myInterpKey'))]": 1,
     'abc${myInterpKey}def': 2
-//@        "[format('abc{0}def', variables('myInterpKey'))]": 2,
     '${myInterpKey}abc${myInterpKey}': 3
-//@        "[format('{0}abc{1}', variables('myInterpKey'), variables('myInterpKey'))]": 3
   }
 }
 
 resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
-//@    {
-//@      "type": "My.Rp/mockResource",
-//@      "apiVersion": "2020-01-01",
-//@      "name": "test",
-//@    },
   name: 'test'
   properties: {
-//@      "properties": {
-//@      }
     // both key and value should be escaped in template output
     '[resourceGroup().location]': '[resourceGroup().location]'
-//@        "[[resourceGroup().location]": "[[resourceGroup().location]"
   }
 }
 
 param shouldDeployVm bool = true
-//@    "shouldDeployVm": {
-//@      "type": "bool",
-//@      "defaultValue": true
-//@    }
 
 @sys.description('this is vmWithCondition')
-//@        "description": "this is vmWithCondition"
 resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (shouldDeployVm) {
-//@    {
-//@      "condition": "[parameters('shouldDeployVm')]",
-//@      "type": "Microsoft.Compute/virtualMachines",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "vmName",
-//@      "metadata": {
-//@      }
-//@    },
   name: 'vmName'
   location: 'westus'
-//@      "location": "westus",
   properties: {
-//@      "properties": {
-//@      },
     osProfile: {
-//@        "osProfile": {
-//@        }
       windowsConfiguration: {
-//@          "windowsConfiguration": {
-//@          }
         enableAutomaticUpdates: true
-//@            "enableAutomaticUpdates": true
       }
     }
   }
 }
 
 @sys.description('this is another vmWithCondition')
-//@        "description": "this is another vmWithCondition"
 resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
-//@    {
-//@      "type": "Microsoft.Compute/virtualMachines",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "vmName2",
-//@      "metadata": {
-//@      }
-//@    },
                     if (shouldDeployVm) {
-//@      "condition": "[parameters('shouldDeployVm')]",
   name: 'vmName2'
   location: 'westus'
-//@      "location": "westus",
   properties: {
-//@      "properties": {
-//@      },
     osProfile: {
-//@        "osProfile": {
-//@        }
       windowsConfiguration: {
-//@          "windowsConfiguration": {
-//@          }
         enableAutomaticUpdates: true
-//@            "enableAutomaticUpdates": true
       }
     }
   }
 }
 
 resource extension1 'My.Rp/extensionResource@2020-12-01' = {
-//@    {
-//@      "type": "My.Rp/extensionResource",
-//@      "apiVersion": "2020-12-01",
-//@      "scope": "[format('Microsoft.Compute/virtualMachines/{0}', 'vmName')]",
-//@      "name": "extension",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Compute/virtualMachines', 'vmName')]"
-//@      ]
-//@    },
   name: 'extension'
   scope: vmWithCondition
 }
 
 resource extension2 'My.Rp/extensionResource@2020-12-01' = {
-//@    {
-//@      "type": "My.Rp/extensionResource",
-//@      "apiVersion": "2020-12-01",
-//@      "scope": "[extensionResourceId(format('Microsoft.Compute/virtualMachines/{0}', 'vmName'), 'My.Rp/extensionResource', 'extension')]",
-//@      "name": "extension",
-//@      "dependsOn": [
-//@        "[extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension')]"
-//@      ]
-//@    },
   name: 'extension'
   scope: extension1
 }
 
 resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
-//@    {
-//@      "type": "My.Rp/mockResource",
-//@      "apiVersion": "2020-01-01",
-//@      "name": "extensionDependencies",
-//@      "dependsOn": [
-//@        "[extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension')]",
-//@        "[extensionResourceId(extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension'), 'My.Rp/extensionResource', 'extension')]",
-//@        "[resourceId('Microsoft.Compute/virtualMachines', 'vmName')]"
-//@      ]
-//@    },
   name: 'extensionDependencies'
   properties: {
-//@      "properties": {
-//@      },
     res1: vmWithCondition.id
-//@        "res1": "[resourceId('Microsoft.Compute/virtualMachines', 'vmName')]",
     res1runtime: vmWithCondition.properties.something
-//@        "res1runtime": "[reference(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), '2020-06-01').something]",
     res2: extension1.id
-//@        "res2": "[extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension')]",
     res2runtime: extension1.properties.something
-//@        "res2runtime": "[reference(extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension'), '2020-12-01').something]",
     res3: extension2.id
-//@        "res3": "[extensionResourceId(extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension'), 'My.Rp/extensionResource', 'extension')]",
     res3runtime: extension2.properties.something
-//@        "res3runtime": "[reference(extensionResourceId(extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension'), 'My.Rp/extensionResource', 'extension'), '2020-12-01').something]"
   }
 }
 
@@ -606,226 +285,88 @@ resource existing2 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
 }
 
 resource extension3 'My.Rp/extensionResource@2020-12-01' = {
-//@    {
-//@      "type": "My.Rp/extensionResource",
-//@      "apiVersion": "2020-12-01",
-//@      "scope": "[extensionResourceId(extensionResourceId(format('Microsoft.Compute/virtualMachines/{0}', 'vmName'), 'My.Rp/extensionResource', 'extension'), 'Mock.Rp/existingExtensionResource', 'existing1')]",
-//@      "name": "extension3",
-//@      "dependsOn": [
-//@        "[extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension')]"
-//@      ]
-//@    },
   name: 'extension3'
   scope: existing1
 }
 
 /*
   valid loop cases
-*/ 
+*/
 var storageAccounts = [
-//@    "storageAccounts": [
-//@    ],
   {
-//@      {
-//@      },
     name: 'one'
-//@        "name": "one",
     location: 'eastus2'
-//@        "location": "eastus2"
   }
   {
-//@      {
-//@      }
     name: 'two'
-//@        "name": "two",
     location: 'westus'
-//@        "location": "westus"
   }
 ]
 
 // just a storage account loop
 @sys.description('this is just a storage account loop')
-//@        "description": "this is just a storage account loop"
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
-//@    {
-//@      "copy": {
-//@        "name": "storageResources",
-//@        "count": "[length(variables('storageAccounts'))]"
-//@      },
-//@      "type": "Microsoft.Storage/storageAccounts",
-//@      "apiVersion": "2019-06-01",
-//@      "name": "[variables('storageAccounts')[copyIndex()].name]",
-//@      "metadata": {
-//@      }
-//@    },
   name: account.name
   location: account.location
-//@      "location": "[variables('storageAccounts')[copyIndex()].location]",
   sku: {
-//@      "sku": {
-//@      },
     name: 'Standard_LRS'
-//@        "name": "Standard_LRS"
   }
   kind: 'StorageV2'
-//@      "kind": "StorageV2",
 }]
 
 // storage account loop with index
 @sys.description('this is just a storage account loop with index')
-//@        "description": "this is just a storage account loop with index"
 resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, i) in storageAccounts: {
-//@    {
-//@      "copy": {
-//@        "name": "storageResourcesWithIndex",
-//@        "count": "[length(variables('storageAccounts'))]"
-//@      },
-//@      "type": "Microsoft.Storage/storageAccounts",
-//@      "apiVersion": "2019-06-01",
-//@      "name": "[format('{0}{1}', variables('storageAccounts')[copyIndex()].name, copyIndex())]",
-//@      "metadata": {
-//@      }
-//@    },
   name: '${account.name}${i}'
   location: account.location
-//@      "location": "[variables('storageAccounts')[copyIndex()].location]",
   sku: {
-//@      "sku": {
-//@      },
     name: 'Standard_LRS'
-//@        "name": "Standard_LRS"
   }
   kind: 'StorageV2'
-//@      "kind": "StorageV2",
 }]
 
 // basic nested loop
 @sys.description('this is just a basic nested loop')
-//@        "description": "this is just a basic nested loop"
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@    {
-//@      "copy": {
-//@        "name": "vnet",
-//@        "count": "[length(range(0, 3))]"
-//@      },
-//@      "type": "Microsoft.Network/virtualNetworks",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "[format('vnet-{0}', range(0, 3)[copyIndex()])]",
-//@      "metadata": {
-//@      }
-//@    },
   name: 'vnet-${i}'
   properties: {
-//@      "properties": {
-//@        "copy": [
-//@        ]
-//@      },
     subnets: [for j in range(0, 4): {
-//@          {
-//@            "name": "subnets",
-//@            "count": "[length(range(0, 4))]",
-//@            "input": {
-//@            }
-//@          }
       // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
-     
+
       // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
-//@              "name": "[format('subnet-{0}-{1}', range(0, 3)[copyIndex()], range(0, 4)[copyIndex('subnets')])]"
     }]
   }
 }]
 
 // duplicate identifiers within the loop are allowed
 resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@    {
-//@      "copy": {
-//@        "name": "duplicateIdentifiersWithinLoop",
-//@        "count": "[length(range(0, 3))]"
-//@      },
-//@      "type": "Microsoft.Network/virtualNetworks",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "[format('vnet-{0}', range(0, 3)[copyIndex()])]",
-//@    },
   name: 'vnet-${i}'
   properties: {
-//@      "properties": {
-//@        "copy": [
-//@        ]
-//@      }
     subnets: [for i in range(0, 4): {
-//@          {
-//@            "name": "subnets",
-//@            "count": "[length(range(0, 4))]",
-//@            "input": {
-//@            }
-//@          }
       name: 'subnet-${i}-${i}'
-//@              "name": "[format('subnet-{0}-{1}', range(0, 4)[copyIndex('subnets')], range(0, 4)[copyIndex('subnets')])]"
     }]
   }
 }]
 
 // duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
 var canHaveDuplicatesAcrossScopes = 'hello'
-//@    "canHaveDuplicatesAcrossScopes": "hello",
 resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
-//@    {
-//@      "copy": {
-//@        "name": "duplicateInGlobalAndOneLoop",
-//@        "count": "[length(range(0, 3))]"
-//@      },
-//@      "type": "Microsoft.Network/virtualNetworks",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "[format('vnet-{0}', range(0, 3)[copyIndex()])]",
-//@    },
   name: 'vnet-${canHaveDuplicatesAcrossScopes}'
   properties: {
-//@      "properties": {
-//@        "copy": [
-//@        ]
-//@      }
     subnets: [for i in range(0, 4): {
-//@          {
-//@            "name": "subnets",
-//@            "count": "[length(range(0, 4))]",
-//@            "input": {
-//@            }
-//@          }
       name: 'subnet-${i}-${i}'
-//@              "name": "[format('subnet-{0}-{1}', range(0, 4)[copyIndex('subnets')], range(0, 4)[copyIndex('subnets')])]"
     }]
   }
 }]
 
 // duplicate in global and multiple loop scopes are allowed (inner hides the outer)
 var duplicatesEverywhere = 'hello'
-//@    "duplicatesEverywhere": "hello",
 resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
-//@    {
-//@      "copy": {
-//@        "name": "duplicateInGlobalAndTwoLoops",
-//@        "count": "[length(range(0, 3))]"
-//@      },
-//@      "type": "Microsoft.Network/virtualNetworks",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "[format('vnet-{0}', range(0, 3)[copyIndex()])]",
-//@    },
   name: 'vnet-${duplicatesEverywhere}'
   properties: {
-//@      "properties": {
-//@        "copy": [
-//@        ]
-//@      }
     subnets: [for duplicatesEverywhere in range(0, 4): {
-//@          {
-//@            "name": "subnets",
-//@            "count": "[length(range(0, 4))]",
-//@            "input": {
-//@            }
-//@          }
       name: 'subnet-${duplicatesEverywhere}'
-//@              "name": "[format('subnet-{0}', range(0, 4)[copyIndex('subnets')])]"
     }]
   }
 }]
@@ -834,244 +375,92 @@ resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06
   Scope values created via array access on a resource collection
 */
 resource dnsZones 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in range(0,4): {
-//@    {
-//@      "copy": {
-//@        "name": "dnsZones",
-//@        "count": "[length(range(0, 4))]"
-//@      },
-//@      "type": "Microsoft.Network/dnsZones",
-//@      "apiVersion": "2018-05-01",
-//@      "name": "[format('zone{0}', range(0, 4)[copyIndex()])]",
-//@    },
   name: 'zone${zone}'
   location: 'global'
-//@      "location": "global"
 }]
 
 resource locksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for lock in range(0,2): {
-//@    {
-//@      "copy": {
-//@        "name": "locksOnZones",
-//@        "count": "[length(range(0, 2))]"
-//@      },
-//@      "type": "Microsoft.Authorization/locks",
-//@      "apiVersion": "2016-09-01",
-//@      "scope": "[format('Microsoft.Network/dnsZones/{0}', format('zone{0}', range(0, 4)[range(0, 2)[copyIndex()]]))]",
-//@      "name": "[format('lock{0}', range(0, 2)[copyIndex()])]",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Network/dnsZones', format('zone{0}', range(0, 4)[range(0, 2)[copyIndex()]]))]"
-//@      ]
-//@    },
   name: 'lock${lock}'
   properties: {
-//@      "properties": {
-//@      },
     level: 'CanNotDelete'
-//@        "level": "CanNotDelete"
   }
   scope: dnsZones[lock]
 }]
 
 resource moreLocksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for (lock, i) in range(0,3): {
-//@    {
-//@      "copy": {
-//@        "name": "moreLocksOnZones",
-//@        "count": "[length(range(0, 3))]"
-//@      },
-//@      "type": "Microsoft.Authorization/locks",
-//@      "apiVersion": "2016-09-01",
-//@      "scope": "[format('Microsoft.Network/dnsZones/{0}', format('zone{0}', range(0, 4)[copyIndex()]))]",
-//@      "name": "[format('another{0}', copyIndex())]",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Network/dnsZones', format('zone{0}', range(0, 4)[copyIndex()]))]"
-//@      ]
-//@    },
   name: 'another${i}'
   properties: {
-//@      "properties": {
-//@      },
     level: 'ReadOnly'
-//@        "level": "ReadOnly"
   }
   scope: dnsZones[i]
 }]
 
 resource singleLockOnFirstZone 'Microsoft.Authorization/locks@2016-09-01' = {
-//@    {
-//@      "type": "Microsoft.Authorization/locks",
-//@      "apiVersion": "2016-09-01",
-//@      "scope": "[format('Microsoft.Network/dnsZones/{0}', format('zone{0}', range(0, 4)[0]))]",
-//@      "name": "single-lock",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Network/dnsZones', format('zone{0}', range(0, 4)[0]))]"
-//@      ]
-//@    },
   name: 'single-lock'
   properties: {
-//@      "properties": {
-//@      },
     level: 'ReadOnly'
-//@        "level": "ReadOnly"
   }
   scope: dnsZones[0]
 }
 
 
 resource p1_vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@    {
-//@      "type": "Microsoft.Network/virtualNetworks",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "myVnet",
-//@    },
   location: resourceGroup().location
-//@      "location": "[resourceGroup().location]",
   name: 'myVnet'
   properties: {
-//@      "properties": {
-//@      }
     addressSpace: {
-//@        "addressSpace": {
-//@        }
       addressPrefixes: [
-//@          "addressPrefixes": [
-//@          ]
         '10.0.0.0/20'
-//@            "10.0.0.0/20"
       ]
     }
   }
 }
 
 resource p1_subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@    {
-//@      "type": "Microsoft.Network/virtualNetworks/subnets",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "[format('{0}/{1}', 'myVnet', 'subnet1')]",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Network/virtualNetworks', 'myVnet')]"
-//@      ]
-//@    },
   parent: p1_vnet
   name: 'subnet1'
   properties: {
-//@      "properties": {
-//@      },
     addressPrefix: '10.0.0.0/24'
-//@        "addressPrefix": "10.0.0.0/24"
   }
 }
 
 resource p1_subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@    {
-//@      "type": "Microsoft.Network/virtualNetworks/subnets",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "[format('{0}/{1}', 'myVnet', 'subnet2')]",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Network/virtualNetworks', 'myVnet')]"
-//@      ]
-//@    },
   parent: p1_vnet
   name: 'subnet2'
   properties: {
-//@      "properties": {
-//@      },
     addressPrefix: '10.0.1.0/24'
-//@        "addressPrefix": "10.0.1.0/24"
   }
 }
 
 output p1_subnet1prefix string = p1_subnet1.properties.addressPrefix
-//@    "p1_subnet1prefix": {
-//@      "type": "string",
-//@      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks/subnets', 'myVnet', 'subnet1'), '2020-06-01').addressPrefix]"
-//@    },
 output p1_subnet1name string = p1_subnet1.name
-//@    "p1_subnet1name": {
-//@      "type": "string",
-//@      "value": "subnet1"
-//@    },
 output p1_subnet1type string = p1_subnet1.type
-//@    "p1_subnet1type": {
-//@      "type": "string",
-//@      "value": "Microsoft.Network/virtualNetworks/subnets"
-//@    },
 output p1_subnet1id string = p1_subnet1.id
-//@    "p1_subnet1id": {
-//@      "type": "string",
-//@      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'myVnet', 'subnet1')]"
-//@    },
 
 // parent property with extension resource
 resource p2_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
-//@    {
-//@      "type": "Microsoft.Rp1/resource1",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "res1"
-//@    },
   name: 'res1'
 }
 
 resource p2_res1child 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@    {
-//@      "type": "Microsoft.Rp1/resource1/child1",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "[format('{0}/{1}', 'res1', 'child1')]",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Rp1/resource1', 'res1')]"
-//@      ]
-//@    },
   parent: p2_res1
   name: 'child1'
 }
 
 resource p2_res2 'Microsoft.Rp2/resource2@2020-06-01' = {
-//@    {
-//@      "type": "Microsoft.Rp2/resource2",
-//@      "apiVersion": "2020-06-01",
-//@      "scope": "[format('Microsoft.Rp1/resource1/{0}/child1/{1}', 'res1', 'child1')]",
-//@      "name": "res2",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')]"
-//@      ]
-//@    },
   scope: p2_res1child
   name: 'res2'
 }
 
 resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
-//@    {
-//@      "type": "Microsoft.Rp2/resource2/child2",
-//@      "apiVersion": "2020-06-01",
-//@      "scope": "[format('Microsoft.Rp1/resource1/{0}/child1/{1}', 'res1', 'child1')]",
-//@      "name": "[format('{0}/{1}', 'res2', 'child2')]",
-//@      "dependsOn": [
-//@        "[extensionResourceId(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), 'Microsoft.Rp2/resource2', 'res2')]"
-//@      ]
-//@    },
   parent: p2_res2
   name: 'child2'
 }
 
 output p2_res2childprop string = p2_res2child.properties.someProp
-//@    "p2_res2childprop": {
-//@      "type": "string",
-//@      "value": "[reference(extensionResourceId(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), 'Microsoft.Rp2/resource2/child2', 'res2', 'child2'), '2020-06-01').someProp]"
-//@    },
 output p2_res2childname string = p2_res2child.name
-//@    "p2_res2childname": {
-//@      "type": "string",
-//@      "value": "child2"
-//@    },
 output p2_res2childtype string = p2_res2child.type
-//@    "p2_res2childtype": {
-//@      "type": "string",
-//@      "value": "Microsoft.Rp2/resource2/child2"
-//@    },
 output p2_res2childid string = p2_res2child.id
-//@    "p2_res2childid": {
-//@      "type": "string",
-//@      "value": "[extensionResourceId(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), 'Microsoft.Rp2/resource2/child2', 'res2', 'child2')]"
-//@    },
 
 // parent property with 'existing' resource
 resource p3_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
@@ -1079,35 +468,14 @@ resource p3_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
 }
 
 resource p3_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@    {
-//@      "type": "Microsoft.Rp1/resource1/child1",
-//@      "apiVersion": "2020-06-01",
-//@      "name": "[format('{0}/{1}', 'res1', 'child1')]"
-//@    },
   parent: p3_res1
   name: 'child1'
 }
 
 output p3_res1childprop string = p3_child1.properties.someProp
-//@    "p3_res1childprop": {
-//@      "type": "string",
-//@      "value": "[reference(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), '2020-06-01').someProp]"
-//@    },
 output p3_res1childname string = p3_child1.name
-//@    "p3_res1childname": {
-//@      "type": "string",
-//@      "value": "child1"
-//@    },
 output p3_res1childtype string = p3_child1.type
-//@    "p3_res1childtype": {
-//@      "type": "string",
-//@      "value": "Microsoft.Rp1/resource1/child1"
-//@    },
 output p3_res1childid string = p3_child1.id
-//@    "p3_res1childid": {
-//@      "type": "string",
-//@      "value": "[resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')]"
-//@    },
 
 // parent & child with 'existing'
 resource p4_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
@@ -1121,83 +489,51 @@ resource p4_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' existing = {
 }
 
 output p4_res1childprop string = p4_child1.properties.someProp
-//@    "p4_res1childprop": {
-//@      "type": "string",
-//@      "value": "[reference(tenantResourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), '2020-06-01').someProp]"
-//@    },
 output p4_res1childname string = p4_child1.name
-//@    "p4_res1childname": {
-//@      "type": "string",
-//@      "value": "child1"
-//@    },
 output p4_res1childtype string = p4_child1.type
-//@    "p4_res1childtype": {
-//@      "type": "string",
-//@      "value": "Microsoft.Rp1/resource1/child1"
-//@    },
 output p4_res1childid string = p4_child1.id
-//@    "p4_res1childid": {
-//@      "type": "string",
-//@      "value": "[tenantResourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')]"
-//@    }
 
 // parent & nested child with decorators https://github.com/Azure/bicep/issues/10970
 var dbs = ['db1', 'db2','db3']
-//@    "dbs": [
-//@      "db1",
-//@      "db2",
-//@      "db3"
-//@    ]
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
-//@    {
-//@      "type": "Microsoft.Sql/servers",
-//@      "apiVersion": "2021-11-01",
-//@      "name": "sql-server-name",
-//@    }
   name: 'sql-server-name'
   location: 'polandcentral'
-//@      "location": "polandcentral"
 
   @batchSize(1)
   @description('Sql Databases')
-//@        "description": "Sql Databases"
   resource sqlDatabases 'databases' = [for db in dbs: {
-//@    {
-//@      "copy": {
-//@        "name": "sqlDatabases",
-//@        "count": "[length(variables('dbs'))]",
-//@        "mode": "serial",
-//@        "batchSize": 1
-//@      },
-//@      "type": "Microsoft.Sql/servers/databases",
-//@      "apiVersion": "2021-11-01",
-//@      "name": "[format('{0}/{1}', 'sql-server-name', variables('dbs')[copyIndex()])]",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Sql/servers', 'sql-server-name')]"
-//@      ],
-//@      "metadata": {
-//@      }
-//@    },
     name: db
     location: 'polandcentral'
-//@      "location": "polandcentral",
   }]
 
   @description('Primary Sql Database')
-//@        "description": "Primary Sql Database"
   resource primaryDb 'databases' = {
-//@    {
-//@      "type": "Microsoft.Sql/servers/databases",
-//@      "apiVersion": "2021-11-01",
-//@      "name": "[format('{0}/{1}', 'sql-server-name', 'primary-db')]",
-//@      "dependsOn": [
-//@        "[resourceId('Microsoft.Sql/servers', 'sql-server-name')]"
-//@      ],
-//@      "metadata": {
-//@      }
-//@    },
     name: 'primary-db'
     location: 'polandcentral'
-//@      "location": "polandcentral",
+
+    resource threatProtection 'advancedThreatProtectionSettings' = {
+      name: 'Default'
+      properties: {
+        state: 'Enabled'
+      }
+    }
   }
 }
+
+//nameof
+var nameof1 = nameof(sqlServer)
+var nameof2 = nameof(sqlServer.location)
+var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
+var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
+var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
+
+var sqlConfig = {
+  westus: {}
+  'server-name': {}
+}
+
+resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
+  location: nameof(sqlConfig.westus)
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5796807527518784233"
+      "templateHash": "9746601616780415170"
     }
   },
   "parameters": {
@@ -58,9 +58,29 @@
       "db1",
       "db2",
       "db3"
-    ]
+    ],
+    "nameof1": "sqlServer",
+    "nameof2": "location",
+    "nameof3": "minCapacity",
+    "nameof4": "creationTime",
+    "nameof5": "id",
+    "sqlConfig": {
+      "westus": {},
+      "server-name": {}
+    }
   },
   "resources": {
+    "sqlServer::primaryDb::threatProtection": {
+      "type": "Microsoft.Sql/servers/databases/advancedThreatProtectionSettings",
+      "apiVersion": "2021-11-01",
+      "name": "[format('{0}/{1}/{2}', 'sql-server-name', 'primary-db', 'Default')]",
+      "properties": {
+        "state": "Enabled"
+      },
+      "dependsOn": [
+        "sqlServer::primaryDb"
+      ]
+    },
     "sqlServer::sqlDatabases": {
       "copy": {
         "name": "sqlDatabases",
@@ -679,6 +699,12 @@
       "apiVersion": "2021-11-01",
       "name": "sql-server-name",
       "location": "polandcentral"
+    },
+    "sqlServerWithNameof": {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-11-01",
+      "name": "[format('sql-server-nameof-{0}', '''server-name''')]",
+      "location": "westus"
     }
   },
   "outputs": {

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbols.bicep
@@ -1,7 +1,6 @@
 
 @sys.description('this is basicStorage')
 resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@[09:021) Resource basicStorage. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 225
   name: 'basicblobs'
   location: 'westus'
   kind: 'BlobStorage'
@@ -12,13 +11,11 @@ resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 
 @sys.description('this is dnsZone')
 resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
-//@[09:016) Resource dnsZone. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 140
   name: 'myZone'
   location: 'global'
 }
 
 resource myStorageAccount 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@[09:025) Resource myStorageAccount. Type: Microsoft.Storage/storageAccounts@2017-10-01. Declaration start char: 0, length: 469
   name: 'myencryptedone'
   location: 'eastus2'
   properties: {
@@ -43,7 +40,6 @@ resource myStorageAccount 'Microsoft.Storage/storageAccounts@2017-10-01' = {
 }
 
 resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@[09:024) Resource withExpressions. Type: Microsoft.Storage/storageAccounts@2017-10-01. Declaration start char: 0, length: 539
   name: 'myencryptedone2'
   location: 'eastus2'
   properties: {
@@ -71,20 +67,14 @@ resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
 }
 
 param applicationName string = 'to-do-app${uniqueString(resourceGroup().id)}'
-//@[06:021) Parameter applicationName. Type: string. Declaration start char: 0, length: 77
 var hostingPlanName = applicationName // why not just use the param directly?
-//@[04:019) Variable hostingPlanName. Type: string. Declaration start char: 0, length: 37
 
 param appServicePlanTier string
-//@[06:024) Parameter appServicePlanTier. Type: string. Declaration start char: 0, length: 31
 param appServicePlanInstances int
-//@[06:029) Parameter appServicePlanInstances. Type: int. Declaration start char: 0, length: 33
 
 var location = resourceGroup().location
-//@[04:012) Variable location. Type: string. Declaration start char: 0, length: 39
 
 resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
-//@[09:013) Resource farm. Type: Microsoft.Web/serverfarms@2019-08-01. Declaration start char: 0, length: 371
   // dependsOn: resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosAccountName)
   name: hostingPlanName
   location: location
@@ -98,23 +88,17 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
 }
 
 var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
-//@[04:022) Variable cosmosDbResourceId. Type: string. Declaration start char: 0, length: 107
 // comment
 cosmosDb.account)
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
-//@[04:015) Variable cosmosDbRef. Type: any. Declaration start char: 0, length: 64
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference
 // it should not be present at all in the template output as there is nowhere logical to put it
 var cosmosDbEndpoint = cosmosDbRef.documentEndpoint
-//@[04:020) Variable cosmosDbEndpoint. Type: any. Declaration start char: 0, length: 51
 
 param webSiteName string
-//@[06:017) Parameter webSiteName. Type: string. Declaration start char: 0, length: 24
 param cosmosDb object
-//@[06:014) Parameter cosmosDb. Type: object. Declaration start char: 0, length: 21
 resource site 'Microsoft.Web/sites@2019-08-01' = {
-//@[09:013) Resource site. Type: Microsoft.Web/sites@2019-08-01. Declaration start char: 0, length: 689
   name: webSiteName
   location: location
   properties: {
@@ -143,17 +127,12 @@ resource site 'Microsoft.Web/sites@2019-08-01' = {
 }
 
 var _siteApiVersion = site.apiVersion
-//@[04:019) Variable _siteApiVersion. Type: '2019-08-01'. Declaration start char: 0, length: 37
 var _siteType = site.type
-//@[04:013) Variable _siteType. Type: 'Microsoft.Web/sites'. Declaration start char: 0, length: 25
 
 output siteApiVersion string = site.apiVersion
-//@[07:021) Output siteApiVersion. Type: string. Declaration start char: 0, length: 46
 output siteType string = site.type
-//@[07:015) Output siteType. Type: string. Declaration start char: 0, length: 34
 
 resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
-//@[09:015) Resource nested. Type: Microsoft.Resources/deployments@2019-10-01. Declaration start char: 0, length: 354
   name: 'nestedTemplate1'
   properties: {
     mode: 'Incremental'
@@ -169,7 +148,6 @@ resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
 
 // should be able to access the read only properties
 resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
-//@[09:036) Resource accessingReadOnlyProperties. Type: Microsoft.Foo/foos@2019-10-01. Declaration start char: 0, length: 284
   name: 'nestedTemplate1'
   properties: {
     otherId: nested.id
@@ -182,17 +160,14 @@ resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
 }
 
 resource resourceA 'My.Rp/typeA@2020-01-01' = {
-//@[09:018) Resource resourceA. Type: My.Rp/typeA@2020-01-01. Declaration start char: 0, length: 71
   name: 'resourceA'
 }
 
 resource resourceB 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[09:018) Resource resourceB. Type: My.Rp/typeA/typeB@2020-01-01. Declaration start char: 0, length: 92
   name: '${resourceA.name}/myName'
 }
 
 resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[09:018) Resource resourceC. Type: My.Rp/typeA/typeB@2020-01-01. Declaration start char: 0, length: 269
   name: '${resourceA.name}/myName'
   properties: {
     aId: resourceA.id
@@ -204,7 +179,6 @@ resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
 }
 
 var varARuntime = {
-//@[04:015) Variable varARuntime. Type: object. Declaration start char: 0, length: 155
   bId: resourceB.id
   bType: resourceB.type
   bName: resourceB.name
@@ -213,19 +187,15 @@ var varARuntime = {
 }
 
 var varBRuntime = [
-//@[04:015) Variable varBRuntime. Type: [object]. Declaration start char: 0, length: 37
   varARuntime
 ]
 
 var resourceCRef = {
-//@[04:016) Variable resourceCRef. Type: object. Declaration start char: 0, length: 43
   id: resourceC.id
 }
 var setResourceCRef = true
-//@[04:019) Variable setResourceCRef. Type: true. Declaration start char: 0, length: 26
 
 resource resourceD 'My.Rp/typeD@2020-01-01' = {
-//@[09:018) Resource resourceD. Type: My.Rp/typeD@2020-01-01. Declaration start char: 0, length: 231
   name: 'constant'
   properties: {
     runtime: varBRuntime
@@ -235,9 +205,7 @@ resource resourceD 'My.Rp/typeD@2020-01-01' = {
 }
 
 var myInterpKey = 'abc'
-//@[04:015) Variable myInterpKey. Type: 'abc'. Declaration start char: 0, length: 23
 resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
-//@[09:027) Resource resourceWithInterp. Type: My.Rp/interp@2020-01-01. Declaration start char: 0, length: 202
   name: 'interpTest'
   properties: {
     '${myInterpKey}': 1
@@ -247,7 +215,6 @@ resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
 }
 
 resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
-//@[09:029) Resource resourceWithEscaping. Type: My.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 234
   name: 'test'
   properties: {
     // both key and value should be escaped in template output
@@ -256,11 +223,9 @@ resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
 }
 
 param shouldDeployVm bool = true
-//@[06:020) Parameter shouldDeployVm. Type: bool. Declaration start char: 0, length: 32
 
 @sys.description('this is vmWithCondition')
 resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (shouldDeployVm) {
-//@[09:024) Resource vmWithCondition. Type: Microsoft.Compute/virtualMachines@2020-06-01. Declaration start char: 0, length: 308
   name: 'vmName'
   location: 'westus'
   properties: {
@@ -274,7 +239,6 @@ resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (sh
 
 @sys.description('this is another vmWithCondition')
 resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
-//@[09:025) Resource vmWithCondition2. Type: Microsoft.Compute/virtualMachines@2020-06-01. Declaration start char: 0, length: 339
                     if (shouldDeployVm) {
   name: 'vmName2'
   location: 'westus'
@@ -288,19 +252,16 @@ resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
 }
 
 resource extension1 'My.Rp/extensionResource@2020-12-01' = {
-//@[09:019) Resource extension1. Type: My.Rp/extensionResource@2020-12-01. Declaration start char: 0, length: 110
   name: 'extension'
   scope: vmWithCondition
 }
 
 resource extension2 'My.Rp/extensionResource@2020-12-01' = {
-//@[09:019) Resource extension2. Type: My.Rp/extensionResource@2020-12-01. Declaration start char: 0, length: 105
   name: 'extension'
   scope: extension1
 }
 
 resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
-//@[09:030) Resource extensionDependencies. Type: My.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 359
   name: 'extensionDependencies'
   properties: {
     res1: vmWithCondition.id
@@ -314,28 +275,24 @@ resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
 
 @sys.description('this is existing1')
 resource existing1 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[09:018) Resource existing1. Type: Mock.Rp/existingExtensionResource@2020-01-01. Declaration start char: 0, length: 162
   name: 'existing1'
   scope: extension1
 }
 
 resource existing2 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[09:018) Resource existing2. Type: Mock.Rp/existingExtensionResource@2020-01-01. Declaration start char: 0, length: 122
   name: 'existing2'
   scope: existing1
 }
 
 resource extension3 'My.Rp/extensionResource@2020-12-01' = {
-//@[09:019) Resource extension3. Type: My.Rp/extensionResource@2020-12-01. Declaration start char: 0, length: 105
   name: 'extension3'
   scope: existing1
 }
 
 /*
   valid loop cases
-*/ 
+*/
 var storageAccounts = [
-//@[04:019) Variable storageAccounts. Type: [object, object]. Declaration start char: 0, length: 129
   {
     name: 'one'
     location: 'eastus2'
@@ -349,8 +306,6 @@ var storageAccounts = [
 // just a storage account loop
 @sys.description('this is just a storage account loop')
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
-//@[80:087) Local account. Type: object | object. Declaration start char: 80, length: 7
-//@[09:025) Resource storageResources. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 284
   name: account.name
   location: account.location
   sku: {
@@ -362,9 +317,6 @@ resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for 
 // storage account loop with index
 @sys.description('this is just a storage account loop with index')
 resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, i) in storageAccounts: {
-//@[90:097) Local account. Type: object | object. Declaration start char: 90, length: 7
-//@[99:100) Local i. Type: int. Declaration start char: 99, length: 1
-//@[09:034) Resource storageResourcesWithIndex. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 318
   name: '${account.name}${i}'
   location: account.location
   sku: {
@@ -376,14 +328,11 @@ resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01
 // basic nested loop
 @sys.description('this is just a basic nested loop')
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[68:069) Local i. Type: int. Declaration start char: 68, length: 1
-//@[09:013) Resource vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 399
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
-//@[18:019) Local j. Type: int. Declaration start char: 18, length: 1
       // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
-     
+
       // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
@@ -392,12 +341,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 
 // duplicate identifiers within the loop are allowed
 resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[94:095) Local i. Type: int. Declaration start char: 94, length: 1
-//@[09:039) Resource duplicateIdentifiersWithinLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 239
   name: 'vnet-${i}'
   properties: {
     subnets: [for i in range(0, 4): {
-//@[18:019) Local i. Type: int. Declaration start char: 18, length: 1
       name: 'subnet-${i}-${i}'
     }]
   }
@@ -405,14 +351,10 @@ resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-
 
 // duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
 var canHaveDuplicatesAcrossScopes = 'hello'
-//@[04:033) Variable canHaveDuplicatesAcrossScopes. Type: 'hello'. Declaration start char: 0, length: 43
 resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
-//@[91:120) Local canHaveDuplicatesAcrossScopes. Type: int. Declaration start char: 91, length: 29
-//@[09:036) Resource duplicateInGlobalAndOneLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 292
   name: 'vnet-${canHaveDuplicatesAcrossScopes}'
   properties: {
     subnets: [for i in range(0, 4): {
-//@[18:019) Local i. Type: int. Declaration start char: 18, length: 1
       name: 'subnet-${i}-${i}'
     }]
   }
@@ -420,14 +362,10 @@ resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-
 
 // duplicate in global and multiple loop scopes are allowed (inner hides the outer)
 var duplicatesEverywhere = 'hello'
-//@[04:024) Variable duplicatesEverywhere. Type: 'hello'. Declaration start char: 0, length: 34
 resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
-//@[92:112) Local duplicatesEverywhere. Type: int. Declaration start char: 92, length: 20
-//@[09:037) Resource duplicateInGlobalAndTwoLoops. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 308
   name: 'vnet-${duplicatesEverywhere}'
   properties: {
     subnets: [for duplicatesEverywhere in range(0, 4): {
-//@[18:038) Local duplicatesEverywhere. Type: int. Declaration start char: 18, length: 20
       name: 'subnet-${duplicatesEverywhere}'
     }]
   }
@@ -437,15 +375,11 @@ resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06
   Scope values created via array access on a resource collection
 */
 resource dnsZones 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in range(0,4): {
-//@[65:069) Local zone. Type: int. Declaration start char: 65, length: 4
-//@[09:017) Resource dnsZones. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 135
   name: 'zone${zone}'
   location: 'global'
 }]
 
 resource locksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for lock in range(0,2): {
-//@[72:076) Local lock. Type: int. Declaration start char: 72, length: 4
-//@[09:021) Resource locksOnZones. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 194
   name: 'lock${lock}'
   properties: {
     level: 'CanNotDelete'
@@ -454,9 +388,6 @@ resource locksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for lock in 
 }]
 
 resource moreLocksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for (lock, i) in range(0,3): {
-//@[77:081) Local lock. Type: int. Declaration start char: 77, length: 4
-//@[83:084) Local i. Type: int. Declaration start char: 83, length: 1
-//@[09:025) Resource moreLocksOnZones. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 196
   name: 'another${i}'
   properties: {
     level: 'ReadOnly'
@@ -465,7 +396,6 @@ resource moreLocksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for (loc
 }]
 
 resource singleLockOnFirstZone 'Microsoft.Authorization/locks@2016-09-01' = {
-//@[09:030) Resource singleLockOnFirstZone. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 170
   name: 'single-lock'
   properties: {
     level: 'ReadOnly'
@@ -475,7 +405,6 @@ resource singleLockOnFirstZone 'Microsoft.Authorization/locks@2016-09-01' = {
 
 
 resource p1_vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@[09:016) Resource p1_vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 234
   location: resourceGroup().location
   name: 'myVnet'
   properties: {
@@ -488,7 +417,6 @@ resource p1_vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 }
 
 resource p1_subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@[09:019) Resource p1_subnet1. Type: Microsoft.Network/virtualNetworks/subnets@2020-06-01. Declaration start char: 0, length: 175
   parent: p1_vnet
   name: 'subnet1'
   properties: {
@@ -497,7 +425,6 @@ resource p1_subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
 }
 
 resource p1_subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@[09:019) Resource p1_subnet2. Type: Microsoft.Network/virtualNetworks/subnets@2020-06-01. Declaration start char: 0, length: 175
   parent: p1_vnet
   name: 'subnet2'
   properties: {
@@ -506,117 +433,87 @@ resource p1_subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
 }
 
 output p1_subnet1prefix string = p1_subnet1.properties.addressPrefix
-//@[07:023) Output p1_subnet1prefix. Type: string. Declaration start char: 0, length: 68
 output p1_subnet1name string = p1_subnet1.name
-//@[07:021) Output p1_subnet1name. Type: string. Declaration start char: 0, length: 46
 output p1_subnet1type string = p1_subnet1.type
-//@[07:021) Output p1_subnet1type. Type: string. Declaration start char: 0, length: 46
 output p1_subnet1id string = p1_subnet1.id
-//@[07:019) Output p1_subnet1id. Type: string. Declaration start char: 0, length: 42
 
 // parent property with extension resource
 resource p2_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
-//@[09:016) Resource p2_res1. Type: Microsoft.Rp1/resource1@2020-06-01. Declaration start char: 0, length: 76
   name: 'res1'
 }
 
 resource p2_res1child 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[09:021) Resource p2_res1child. Type: Microsoft.Rp1/resource1/child1@2020-06-01. Declaration start char: 0, length: 109
   parent: p2_res1
   name: 'child1'
 }
 
 resource p2_res2 'Microsoft.Rp2/resource2@2020-06-01' = {
-//@[09:016) Resource p2_res2. Type: Microsoft.Rp2/resource2@2020-06-01. Declaration start char: 0, length: 99
   scope: p2_res1child
   name: 'res2'
 }
 
 resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
-//@[09:021) Resource p2_res2child. Type: Microsoft.Rp2/resource2/child2@2020-06-01. Declaration start char: 0, length: 109
   parent: p2_res2
   name: 'child2'
 }
 
 output p2_res2childprop string = p2_res2child.properties.someProp
-//@[07:023) Output p2_res2childprop. Type: string. Declaration start char: 0, length: 65
 output p2_res2childname string = p2_res2child.name
-//@[07:023) Output p2_res2childname. Type: string. Declaration start char: 0, length: 50
 output p2_res2childtype string = p2_res2child.type
-//@[07:023) Output p2_res2childtype. Type: string. Declaration start char: 0, length: 50
 output p2_res2childid string = p2_res2child.id
-//@[07:021) Output p2_res2childid. Type: string. Declaration start char: 0, length: 46
 
 // parent property with 'existing' resource
 resource p3_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[09:016) Resource p3_res1. Type: Microsoft.Rp1/resource1@2020-06-01. Declaration start char: 0, length: 85
   name: 'res1'
 }
 
 resource p3_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[09:018) Resource p3_child1. Type: Microsoft.Rp1/resource1/child1@2020-06-01. Declaration start char: 0, length: 106
   parent: p3_res1
   name: 'child1'
 }
 
 output p3_res1childprop string = p3_child1.properties.someProp
-//@[07:023) Output p3_res1childprop. Type: string. Declaration start char: 0, length: 62
 output p3_res1childname string = p3_child1.name
-//@[07:023) Output p3_res1childname. Type: string. Declaration start char: 0, length: 47
 output p3_res1childtype string = p3_child1.type
-//@[07:023) Output p3_res1childtype. Type: string. Declaration start char: 0, length: 47
 output p3_res1childid string = p3_child1.id
-//@[07:021) Output p3_res1childid. Type: string. Declaration start char: 0, length: 43
 
 // parent & child with 'existing'
 resource p4_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[09:016) Resource p4_res1. Type: Microsoft.Rp1/resource1@2020-06-01. Declaration start char: 0, length: 104
   scope: tenant()
   name: 'res1'
 }
 
 resource p4_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' existing = {
-//@[09:018) Resource p4_child1. Type: Microsoft.Rp1/resource1/child1@2020-06-01. Declaration start char: 0, length: 115
   parent: p4_res1
   name: 'child1'
 }
 
 output p4_res1childprop string = p4_child1.properties.someProp
-//@[07:023) Output p4_res1childprop. Type: string. Declaration start char: 0, length: 62
 output p4_res1childname string = p4_child1.name
-//@[07:023) Output p4_res1childname. Type: string. Declaration start char: 0, length: 47
 output p4_res1childtype string = p4_child1.type
-//@[07:023) Output p4_res1childtype. Type: string. Declaration start char: 0, length: 47
 output p4_res1childid string = p4_child1.id
-//@[07:021) Output p4_res1childid. Type: string. Declaration start char: 0, length: 43
 
 // parent & nested child with decorators https://github.com/Azure/bicep/issues/10970
 var dbs = ['db1', 'db2','db3']
-//@[04:007) Variable dbs. Type: ['db1', 'db2', 'db3']. Declaration start char: 0, length: 30
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
-//@[09:018) Resource sqlServer. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 572
   name: 'sql-server-name'
   location: 'polandcentral'
 
   @batchSize(1)
   @description('Sql Databases')
   resource sqlDatabases 'databases' = [for db in dbs: {
-//@[43:045) Local db. Type: 'db1' | 'db2' | 'db3'. Declaration start char: 43, length: 2
-//@[11:023) Resource sqlDatabases. Type: Microsoft.Sql/servers/databases@2021-11-01[]. Declaration start char: 2, length: 154
     name: db
     location: 'polandcentral'
   }]
 
   @description('Primary Sql Database')
   resource primaryDb 'databases' = {
-//@[11:020) Resource primaryDb. Type: Microsoft.Sql/servers/databases@2021-11-01. Declaration start char: 2, length: 290
     name: 'primary-db'
     location: 'polandcentral'
 
     resource threatProtection 'advancedThreatProtectionSettings' = {
       name: 'Default'
       properties: {
-//@[13:029) Resource threatProtection. Type: Microsoft.Sql/servers/databases/advancedThreatProtectionSettings@2021-11-01. Declaration start char: 4, length: 150
         state: 'Enabled'
       }
     }
@@ -632,14 +529,11 @@ var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
 
 var sqlConfig = {
   westus: {}
-  server: {}
-  'my-rg': {}
+  'server-name': {}
 }
 
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
-  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
   location: nameof(sqlConfig.westus)
-  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }
 
-//@[04:011) Variable nameof1. Type: 'sqlServer'. Declaration start char: 0, length: 31

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbols.bicep
@@ -594,7 +594,7 @@ output p4_res1childid string = p4_child1.id
 var dbs = ['db1', 'db2','db3']
 //@[04:007) Variable dbs. Type: ['db1', 'db2', 'db3']. Declaration start char: 0, length: 30
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
-//@[09:018) Resource sqlServer. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 416
+//@[09:018) Resource sqlServer. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 572
   name: 'sql-server-name'
   location: 'polandcentral'
 
@@ -609,8 +609,37 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
 
   @description('Primary Sql Database')
   resource primaryDb 'databases' = {
-//@[11:020) Resource primaryDb. Type: Microsoft.Sql/servers/databases@2021-11-01. Declaration start char: 2, length: 134
+//@[11:020) Resource primaryDb. Type: Microsoft.Sql/servers/databases@2021-11-01. Declaration start char: 2, length: 290
     name: 'primary-db'
     location: 'polandcentral'
+
+    resource threatProtection 'advancedThreatProtectionSettings' = {
+      name: 'Default'
+      properties: {
+//@[13:029) Resource threatProtection. Type: Microsoft.Sql/servers/databases/advancedThreatProtectionSettings@2021-11-01. Declaration start char: 4, length: 150
+        state: 'Enabled'
+      }
+    }
   }
 }
+
+//nameof
+var nameof1 = nameof(sqlServer)
+var nameof2 = nameof(sqlServer.location)
+var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
+var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
+var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
+
+var sqlConfig = {
+  westus: {}
+  server: {}
+  'my-rg': {}
+}
+
+resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+  location: nameof(sqlConfig.westus)
+  scope: resourceGroup(nameof(sqlConfig['my-rg']))
+}
+
+//@[04:011) Variable nameof1. Type: 'sqlServer'. Declaration start char: 0, length: 31

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[000:13326) ProgramSyntax
+//@[000:14050) ProgramSyntax
 //@[000:00002) ├─Token(NewLine) |\r\n|
 @sys.description('this is basicStorage')
 //@[000:00225) ├─ResourceDeclarationSyntax
@@ -3926,14 +3926,14 @@ var dbs = ['db1', 'db2','db3']
 //@[029:00030) |   └─Token(RightSquare) |]|
 //@[030:00032) ├─Token(NewLine) |\r\n|
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
-//@[000:00416) ├─ResourceDeclarationSyntax
+//@[000:00572) ├─ResourceDeclarationSyntax
 //@[000:00008) | ├─Token(Identifier) |resource|
 //@[009:00018) | ├─IdentifierSyntax
 //@[009:00018) | | └─Token(Identifier) |sqlServer|
 //@[019:00053) | ├─StringSyntax
 //@[019:00053) | | └─Token(StringComplete) |'Microsoft.Sql/servers@2021-11-01'|
 //@[054:00055) | ├─Token(Assignment) |=|
-//@[056:00416) | └─ObjectSyntax
+//@[056:00572) | └─ObjectSyntax
 //@[056:00057) |   ├─Token(LeftBrace) |{|
 //@[057:00059) |   ├─Token(NewLine) |\r\n|
   name: 'sql-server-name'
@@ -4022,7 +4022,7 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
 //@[004:00008) |   ├─Token(NewLine) |\r\n\r\n|
 
   @description('Primary Sql Database')
-//@[002:00136) |   ├─ResourceDeclarationSyntax
+//@[002:00292) |   ├─ResourceDeclarationSyntax
 //@[002:00038) |   | ├─DecoratorSyntax
 //@[002:00003) |   | | ├─Token(At) |@|
 //@[003:00038) |   | | └─FunctionCallSyntax
@@ -4041,7 +4041,7 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
 //@[021:00032) |   | ├─StringSyntax
 //@[021:00032) |   | | └─Token(StringComplete) |'databases'|
 //@[033:00034) |   | ├─Token(Assignment) |=|
-//@[035:00096) |   | └─ObjectSyntax
+//@[035:00252) |   | └─ObjectSyntax
 //@[035:00036) |   |   ├─Token(LeftBrace) |{|
 //@[036:00038) |   |   ├─Token(NewLine) |\r\n|
     name: 'primary-db'
@@ -4053,16 +4053,94 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
 //@[010:00022) |   |   |   └─Token(StringComplete) |'primary-db'|
 //@[022:00024) |   |   ├─Token(NewLine) |\r\n|
     location: 'polandcentral'
+
+    resource threatProtection 'advancedThreatProtectionSettings' = {
 //@[004:00029) |   |   ├─ObjectPropertySyntax
 //@[004:00012) |   |   | ├─IdentifierSyntax
 //@[004:00012) |   |   | | └─Token(Identifier) |location|
 //@[012:00013) |   |   | ├─Token(Colon) |:|
 //@[014:00029) |   |   | └─StringSyntax
 //@[014:00029) |   |   |   └─Token(StringComplete) |'polandcentral'|
-//@[029:00031) |   |   ├─Token(NewLine) |\r\n|
+//@[029:00031) |   |   ├─Token(NewLine) |\n\n|
+      name: 'Default'
+      properties: {
+//@[004:00154) |   |   ├─ResourceDeclarationSyntax
+//@[004:00012) |   |   | ├─Token(Identifier) |resource|
+//@[013:00029) |   |   | ├─IdentifierSyntax
+//@[013:00029) |   |   | | └─Token(Identifier) |threatProtection|
+//@[030:00064) |   |   | ├─StringSyntax
+//@[030:00064) |   |   | | └─Token(StringComplete) |'advancedThreatProtectionSettings'|
+//@[065:00066) |   |   | ├─Token(Assignment) |=|
+//@[067:00154) |   |   | └─ObjectSyntax
+//@[067:00068) |   |   |   ├─Token(LeftBrace) |{|
+//@[068:00070) |   |   |   ├─Token(NewLine) |\r\n|
+        state: 'Enabled'
+//@[006:00021) |   |   |   ├─ObjectPropertySyntax
+//@[006:00010) |   |   |   | ├─IdentifierSyntax
+//@[006:00010) |   |   |   | | └─Token(Identifier) |name|
+//@[010:00011) |   |   |   | ├─Token(Colon) |:|
+//@[012:00021) |   |   |   | └─StringSyntax
+//@[012:00021) |   |   |   |   └─Token(StringComplete) |'Default'|
+//@[021:00023) |   |   |   ├─Token(NewLine) |\r\n|
+      }
+//@[006:00054) |   |   |   ├─ObjectPropertySyntax
+//@[006:00016) |   |   |   | ├─IdentifierSyntax
+//@[006:00016) |   |   |   | | └─Token(Identifier) |properties|
+//@[016:00017) |   |   |   | ├─Token(Colon) |:|
+//@[018:00054) |   |   |   | └─ObjectSyntax
+//@[018:00019) |   |   |   |   ├─Token(LeftBrace) |{|
+//@[019:00021) |   |   |   |   ├─Token(NewLine) |\r\n|
+    }
+//@[008:00024) |   |   |   |   ├─ObjectPropertySyntax
+//@[008:00013) |   |   |   |   | ├─IdentifierSyntax
+//@[008:00013) |   |   |   |   | | └─Token(Identifier) |state|
+//@[013:00014) |   |   |   |   | ├─Token(Colon) |:|
+//@[015:00024) |   |   |   |   | └─StringSyntax
+//@[015:00024) |   |   |   |   |   └─Token(StringComplete) |'Enabled'|
+//@[024:00026) |   |   |   |   ├─Token(NewLine) |\r\n|
   }
+//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
+//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
+}
+
+//nameof
+var nameof1 = nameof(sqlServer)
+var nameof2 = nameof(sqlServer.location)
+var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
+//@[004:00005) |   |   |   └─Token(RightBrace) |}|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
 //@[002:00003) |   |   └─Token(RightBrace) |}|
 //@[003:00005) |   ├─Token(NewLine) |\r\n|
-}
+var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
+
+var sqlConfig = {
+  westus: {}
+  server: {}
+  'my-rg': {}
 //@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00001) └─Token(EndOfFile) ||
+//@[001:00003) ├─Token(NewLine) |\n\n|
+}
+
+resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+//@[008:00009) ├─Token(NewLine) |\n|
+  location: nameof(sqlConfig.westus)
+  scope: resourceGroup(nameof(sqlConfig['my-rg']))
+}
+
+//@[000:00031) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00011) | ├─IdentifierSyntax
+//@[004:00011) | | └─Token(Identifier) |nameof1|
+//@[012:00013) | ├─Token(Assignment) |=|
+//@[014:00031) | └─FunctionCallSyntax
+//@[014:00020) |   ├─IdentifierSyntax
+//@[014:00020) |   | └─Token(Identifier) |nameof|
+//@[020:00021) |   ├─Token(LeftParen) |(|
+//@[021:00030) |   ├─FunctionArgumentSyntax
+//@[021:00030) |   | └─VariableAccessSyntax
+//@[021:00030) |   |   └─IdentifierSyntax
+//@[021:00030) |   |     └─Token(Identifier) |sqlServer|
+//@[030:00031) |   └─Token(RightParen) |)|
+//@[031:00032) ├─Token(NewLine) |\n|

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.syntax.bicep
@@ -1,4146 +1,541 @@
 
-//@[000:14050) ProgramSyntax
-//@[000:00002) ├─Token(NewLine) |\r\n|
 @sys.description('this is basicStorage')
-//@[000:00225) ├─ResourceDeclarationSyntax
-//@[000:00040) | ├─DecoratorSyntax
-//@[000:00001) | | ├─Token(At) |@|
-//@[001:00040) | | └─InstanceFunctionCallSyntax
-//@[001:00004) | |   ├─VariableAccessSyntax
-//@[001:00004) | |   | └─IdentifierSyntax
-//@[001:00004) | |   |   └─Token(Identifier) |sys|
-//@[004:00005) | |   ├─Token(Dot) |.|
-//@[005:00016) | |   ├─IdentifierSyntax
-//@[005:00016) | |   | └─Token(Identifier) |description|
-//@[016:00017) | |   ├─Token(LeftParen) |(|
-//@[017:00039) | |   ├─FunctionArgumentSyntax
-//@[017:00039) | |   | └─StringSyntax
-//@[017:00039) | |   |   └─Token(StringComplete) |'this is basicStorage'|
-//@[039:00040) | |   └─Token(RightParen) |)|
-//@[040:00042) | ├─Token(NewLine) |\r\n|
 resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00021) | ├─IdentifierSyntax
-//@[009:00021) | | └─Token(Identifier) |basicStorage|
-//@[022:00068) | ├─StringSyntax
-//@[022:00068) | | └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2019-06-01'|
-//@[069:00070) | ├─Token(Assignment) |=|
-//@[071:00183) | └─ObjectSyntax
-//@[071:00072) |   ├─Token(LeftBrace) |{|
-//@[072:00074) |   ├─Token(NewLine) |\r\n|
   name: 'basicblobs'
-//@[002:00020) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00020) |   | └─StringSyntax
-//@[008:00020) |   |   └─Token(StringComplete) |'basicblobs'|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
   location: 'westus'
-//@[002:00020) |   ├─ObjectPropertySyntax
-//@[002:00010) |   | ├─IdentifierSyntax
-//@[002:00010) |   | | └─Token(Identifier) |location|
-//@[010:00011) |   | ├─Token(Colon) |:|
-//@[012:00020) |   | └─StringSyntax
-//@[012:00020) |   |   └─Token(StringComplete) |'westus'|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
   kind: 'BlobStorage'
-//@[002:00021) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |kind|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00021) |   | └─StringSyntax
-//@[008:00021) |   |   └─Token(StringComplete) |'BlobStorage'|
-//@[021:00023) |   ├─Token(NewLine) |\r\n|
   sku: {
-//@[002:00039) |   ├─ObjectPropertySyntax
-//@[002:00005) |   | ├─IdentifierSyntax
-//@[002:00005) |   | | └─Token(Identifier) |sku|
-//@[005:00006) |   | ├─Token(Colon) |:|
-//@[007:00039) |   | └─ObjectSyntax
-//@[007:00008) |   |   ├─Token(LeftBrace) |{|
-//@[008:00010) |   |   ├─Token(NewLine) |\r\n|
     name: 'Standard_GRS'
-//@[004:00024) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00024) |   |   | └─StringSyntax
-//@[010:00024) |   |   |   └─Token(StringComplete) |'Standard_GRS'|
-//@[024:00026) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 @sys.description('this is dnsZone')
-//@[000:00140) ├─ResourceDeclarationSyntax
-//@[000:00035) | ├─DecoratorSyntax
-//@[000:00001) | | ├─Token(At) |@|
-//@[001:00035) | | └─InstanceFunctionCallSyntax
-//@[001:00004) | |   ├─VariableAccessSyntax
-//@[001:00004) | |   | └─IdentifierSyntax
-//@[001:00004) | |   |   └─Token(Identifier) |sys|
-//@[004:00005) | |   ├─Token(Dot) |.|
-//@[005:00016) | |   ├─IdentifierSyntax
-//@[005:00016) | |   | └─Token(Identifier) |description|
-//@[016:00017) | |   ├─Token(LeftParen) |(|
-//@[017:00034) | |   ├─FunctionArgumentSyntax
-//@[017:00034) | |   | └─StringSyntax
-//@[017:00034) | |   |   └─Token(StringComplete) |'this is dnsZone'|
-//@[034:00035) | |   └─Token(RightParen) |)|
-//@[035:00037) | ├─Token(NewLine) |\r\n|
 resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00016) | ├─IdentifierSyntax
-//@[009:00016) | | └─Token(Identifier) |dnsZone|
-//@[017:00056) | ├─StringSyntax
-//@[017:00056) | | └─Token(StringComplete) |'Microsoft.Network/dnszones@2018-05-01'|
-//@[057:00058) | ├─Token(Assignment) |=|
-//@[059:00103) | └─ObjectSyntax
-//@[059:00060) |   ├─Token(LeftBrace) |{|
-//@[060:00062) |   ├─Token(NewLine) |\r\n|
   name: 'myZone'
-//@[002:00016) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00016) |   | └─StringSyntax
-//@[008:00016) |   |   └─Token(StringComplete) |'myZone'|
-//@[016:00018) |   ├─Token(NewLine) |\r\n|
   location: 'global'
-//@[002:00020) |   ├─ObjectPropertySyntax
-//@[002:00010) |   | ├─IdentifierSyntax
-//@[002:00010) |   | | └─Token(Identifier) |location|
-//@[010:00011) |   | ├─Token(Colon) |:|
-//@[012:00020) |   | └─StringSyntax
-//@[012:00020) |   |   └─Token(StringComplete) |'global'|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource myStorageAccount 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@[000:00469) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00025) | ├─IdentifierSyntax
-//@[009:00025) | | └─Token(Identifier) |myStorageAccount|
-//@[026:00072) | ├─StringSyntax
-//@[026:00072) | | └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2017-10-01'|
-//@[073:00074) | ├─Token(Assignment) |=|
-//@[075:00469) | └─ObjectSyntax
-//@[075:00076) |   ├─Token(LeftBrace) |{|
-//@[076:00078) |   ├─Token(NewLine) |\r\n|
   name: 'myencryptedone'
-//@[002:00024) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00024) |   | └─StringSyntax
-//@[008:00024) |   |   └─Token(StringComplete) |'myencryptedone'|
-//@[024:00026) |   ├─Token(NewLine) |\r\n|
   location: 'eastus2'
-//@[002:00021) |   ├─ObjectPropertySyntax
-//@[002:00010) |   | ├─IdentifierSyntax
-//@[002:00010) |   | | └─Token(Identifier) |location|
-//@[010:00011) |   | ├─Token(Colon) |:|
-//@[012:00021) |   | └─StringSyntax
-//@[012:00021) |   |   └─Token(StringComplete) |'eastus2'|
-//@[021:00023) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00277) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00277) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     supportsHttpsTrafficOnly: true
-//@[004:00034) |   |   ├─ObjectPropertySyntax
-//@[004:00028) |   |   | ├─IdentifierSyntax
-//@[004:00028) |   |   | | └─Token(Identifier) |supportsHttpsTrafficOnly|
-//@[028:00029) |   |   | ├─Token(Colon) |:|
-//@[030:00034) |   |   | └─BooleanLiteralSyntax
-//@[030:00034) |   |   |   └─Token(TrueKeyword) |true|
-//@[034:00036) |   |   ├─Token(NewLine) |\r\n|
     accessTier: 'Hot'
-//@[004:00021) |   |   ├─ObjectPropertySyntax
-//@[004:00014) |   |   | ├─IdentifierSyntax
-//@[004:00014) |   |   | | └─Token(Identifier) |accessTier|
-//@[014:00015) |   |   | ├─Token(Colon) |:|
-//@[016:00021) |   |   | └─StringSyntax
-//@[016:00021) |   |   |   └─Token(StringComplete) |'Hot'|
-//@[021:00023) |   |   ├─Token(NewLine) |\r\n|
     encryption: {
-//@[004:00196) |   |   ├─ObjectPropertySyntax
-//@[004:00014) |   |   | ├─IdentifierSyntax
-//@[004:00014) |   |   | | └─Token(Identifier) |encryption|
-//@[014:00015) |   |   | ├─Token(Colon) |:|
-//@[016:00196) |   |   | └─ObjectSyntax
-//@[016:00017) |   |   |   ├─Token(LeftBrace) |{|
-//@[017:00019) |   |   |   ├─Token(NewLine) |\r\n|
       keySource: 'Microsoft.Storage'
-//@[006:00036) |   |   |   ├─ObjectPropertySyntax
-//@[006:00015) |   |   |   | ├─IdentifierSyntax
-//@[006:00015) |   |   |   | | └─Token(Identifier) |keySource|
-//@[015:00016) |   |   |   | ├─Token(Colon) |:|
-//@[017:00036) |   |   |   | └─StringSyntax
-//@[017:00036) |   |   |   |   └─Token(StringComplete) |'Microsoft.Storage'|
-//@[036:00038) |   |   |   ├─Token(NewLine) |\r\n|
       services: {
-//@[006:00132) |   |   |   ├─ObjectPropertySyntax
-//@[006:00014) |   |   |   | ├─IdentifierSyntax
-//@[006:00014) |   |   |   | | └─Token(Identifier) |services|
-//@[014:00015) |   |   |   | ├─Token(Colon) |:|
-//@[016:00132) |   |   |   | └─ObjectSyntax
-//@[016:00017) |   |   |   |   ├─Token(LeftBrace) |{|
-//@[017:00019) |   |   |   |   ├─Token(NewLine) |\r\n|
         blob: {
-//@[008:00051) |   |   |   |   ├─ObjectPropertySyntax
-//@[008:00012) |   |   |   |   | ├─IdentifierSyntax
-//@[008:00012) |   |   |   |   | | └─Token(Identifier) |blob|
-//@[012:00013) |   |   |   |   | ├─Token(Colon) |:|
-//@[014:00051) |   |   |   |   | └─ObjectSyntax
-//@[014:00015) |   |   |   |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           enabled: true
-//@[010:00023) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00017) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00017) |   |   |   |   |   | | └─Token(Identifier) |enabled|
-//@[017:00018) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[019:00023) |   |   |   |   |   | └─BooleanLiteralSyntax
-//@[019:00023) |   |   |   |   |   |   └─Token(TrueKeyword) |true|
-//@[023:00025) |   |   |   |   |   ├─Token(NewLine) |\r\n|
         }
-//@[008:00009) |   |   |   |   |   └─Token(RightBrace) |}|
-//@[009:00011) |   |   |   |   ├─Token(NewLine) |\r\n|
         file: {
-//@[008:00051) |   |   |   |   ├─ObjectPropertySyntax
-//@[008:00012) |   |   |   |   | ├─IdentifierSyntax
-//@[008:00012) |   |   |   |   | | └─Token(Identifier) |file|
-//@[012:00013) |   |   |   |   | ├─Token(Colon) |:|
-//@[014:00051) |   |   |   |   | └─ObjectSyntax
-//@[014:00015) |   |   |   |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           enabled: true
-//@[010:00023) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00017) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00017) |   |   |   |   |   | | └─Token(Identifier) |enabled|
-//@[017:00018) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[019:00023) |   |   |   |   |   | └─BooleanLiteralSyntax
-//@[019:00023) |   |   |   |   |   |   └─Token(TrueKeyword) |true|
-//@[023:00025) |   |   |   |   |   ├─Token(NewLine) |\r\n|
         }
-//@[008:00009) |   |   |   |   |   └─Token(RightBrace) |}|
-//@[009:00011) |   |   |   |   ├─Token(NewLine) |\r\n|
       }
-//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
-//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
     }
-//@[004:00005) |   |   |   └─Token(RightBrace) |}|
-//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
   kind: 'StorageV2'
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |kind|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00019) |   | └─StringSyntax
-//@[008:00019) |   |   └─Token(StringComplete) |'StorageV2'|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   sku: {
-//@[002:00039) |   ├─ObjectPropertySyntax
-//@[002:00005) |   | ├─IdentifierSyntax
-//@[002:00005) |   | | └─Token(Identifier) |sku|
-//@[005:00006) |   | ├─Token(Colon) |:|
-//@[007:00039) |   | └─ObjectSyntax
-//@[007:00008) |   |   ├─Token(LeftBrace) |{|
-//@[008:00010) |   |   ├─Token(NewLine) |\r\n|
     name: 'Standard_LRS'
-//@[004:00024) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00024) |   |   | └─StringSyntax
-//@[010:00024) |   |   |   └─Token(StringComplete) |'Standard_LRS'|
-//@[024:00026) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@[000:00539) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00024) | ├─IdentifierSyntax
-//@[009:00024) | | └─Token(Identifier) |withExpressions|
-//@[025:00071) | ├─StringSyntax
-//@[025:00071) | | └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2017-10-01'|
-//@[072:00073) | ├─Token(Assignment) |=|
-//@[074:00539) | └─ObjectSyntax
-//@[074:00075) |   ├─Token(LeftBrace) |{|
-//@[075:00077) |   ├─Token(NewLine) |\r\n|
   name: 'myencryptedone2'
-//@[002:00025) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00025) |   | └─StringSyntax
-//@[008:00025) |   |   └─Token(StringComplete) |'myencryptedone2'|
-//@[025:00027) |   ├─Token(NewLine) |\r\n|
   location: 'eastus2'
-//@[002:00021) |   ├─ObjectPropertySyntax
-//@[002:00010) |   | ├─IdentifierSyntax
-//@[002:00010) |   | | └─Token(Identifier) |location|
-//@[010:00011) |   | ├─Token(Colon) |:|
-//@[012:00021) |   | └─StringSyntax
-//@[012:00021) |   |   └─Token(StringComplete) |'eastus2'|
-//@[021:00023) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00304) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00304) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     supportsHttpsTrafficOnly: !false
-//@[004:00036) |   |   ├─ObjectPropertySyntax
-//@[004:00028) |   |   | ├─IdentifierSyntax
-//@[004:00028) |   |   | | └─Token(Identifier) |supportsHttpsTrafficOnly|
-//@[028:00029) |   |   | ├─Token(Colon) |:|
-//@[030:00036) |   |   | └─UnaryOperationSyntax
-//@[030:00031) |   |   |   ├─Token(Exclamation) |!|
-//@[031:00036) |   |   |   └─BooleanLiteralSyntax
-//@[031:00036) |   |   |     └─Token(FalseKeyword) |false|
-//@[036:00038) |   |   ├─Token(NewLine) |\r\n|
     accessTier: true ? 'Hot' : 'Cold'
-//@[004:00037) |   |   ├─ObjectPropertySyntax
-//@[004:00014) |   |   | ├─IdentifierSyntax
-//@[004:00014) |   |   | | └─Token(Identifier) |accessTier|
-//@[014:00015) |   |   | ├─Token(Colon) |:|
-//@[016:00037) |   |   | └─TernaryOperationSyntax
-//@[016:00020) |   |   |   ├─BooleanLiteralSyntax
-//@[016:00020) |   |   |   | └─Token(TrueKeyword) |true|
-//@[021:00022) |   |   |   ├─Token(Question) |?|
-//@[023:00028) |   |   |   ├─StringSyntax
-//@[023:00028) |   |   |   | └─Token(StringComplete) |'Hot'|
-//@[029:00030) |   |   |   ├─Token(Colon) |:|
-//@[031:00037) |   |   |   └─StringSyntax
-//@[031:00037) |   |   |     └─Token(StringComplete) |'Cold'|
-//@[037:00039) |   |   ├─Token(NewLine) |\r\n|
     encryption: {
-//@[004:00205) |   |   ├─ObjectPropertySyntax
-//@[004:00014) |   |   | ├─IdentifierSyntax
-//@[004:00014) |   |   | | └─Token(Identifier) |encryption|
-//@[014:00015) |   |   | ├─Token(Colon) |:|
-//@[016:00205) |   |   | └─ObjectSyntax
-//@[016:00017) |   |   |   ├─Token(LeftBrace) |{|
-//@[017:00019) |   |   |   ├─Token(NewLine) |\r\n|
       keySource: 'Microsoft.Storage'
-//@[006:00036) |   |   |   ├─ObjectPropertySyntax
-//@[006:00015) |   |   |   | ├─IdentifierSyntax
-//@[006:00015) |   |   |   | | └─Token(Identifier) |keySource|
-//@[015:00016) |   |   |   | ├─Token(Colon) |:|
-//@[017:00036) |   |   |   | └─StringSyntax
-//@[017:00036) |   |   |   |   └─Token(StringComplete) |'Microsoft.Storage'|
-//@[036:00038) |   |   |   ├─Token(NewLine) |\r\n|
       services: {
-//@[006:00141) |   |   |   ├─ObjectPropertySyntax
-//@[006:00014) |   |   |   | ├─IdentifierSyntax
-//@[006:00014) |   |   |   | | └─Token(Identifier) |services|
-//@[014:00015) |   |   |   | ├─Token(Colon) |:|
-//@[016:00141) |   |   |   | └─ObjectSyntax
-//@[016:00017) |   |   |   |   ├─Token(LeftBrace) |{|
-//@[017:00019) |   |   |   |   ├─Token(NewLine) |\r\n|
         blob: {
-//@[008:00060) |   |   |   |   ├─ObjectPropertySyntax
-//@[008:00012) |   |   |   |   | ├─IdentifierSyntax
-//@[008:00012) |   |   |   |   | | └─Token(Identifier) |blob|
-//@[012:00013) |   |   |   |   | ├─Token(Colon) |:|
-//@[014:00060) |   |   |   |   | └─ObjectSyntax
-//@[014:00015) |   |   |   |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           enabled: true || false
-//@[010:00032) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00017) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00017) |   |   |   |   |   | | └─Token(Identifier) |enabled|
-//@[017:00018) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[019:00032) |   |   |   |   |   | └─BinaryOperationSyntax
-//@[019:00023) |   |   |   |   |   |   ├─BooleanLiteralSyntax
-//@[019:00023) |   |   |   |   |   |   | └─Token(TrueKeyword) |true|
-//@[024:00026) |   |   |   |   |   |   ├─Token(LogicalOr) ||||
-//@[027:00032) |   |   |   |   |   |   └─BooleanLiteralSyntax
-//@[027:00032) |   |   |   |   |   |     └─Token(FalseKeyword) |false|
-//@[032:00034) |   |   |   |   |   ├─Token(NewLine) |\r\n|
         }
-//@[008:00009) |   |   |   |   |   └─Token(RightBrace) |}|
-//@[009:00011) |   |   |   |   ├─Token(NewLine) |\r\n|
         file: {
-//@[008:00051) |   |   |   |   ├─ObjectPropertySyntax
-//@[008:00012) |   |   |   |   | ├─IdentifierSyntax
-//@[008:00012) |   |   |   |   | | └─Token(Identifier) |file|
-//@[012:00013) |   |   |   |   | ├─Token(Colon) |:|
-//@[014:00051) |   |   |   |   | └─ObjectSyntax
-//@[014:00015) |   |   |   |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           enabled: true
-//@[010:00023) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00017) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00017) |   |   |   |   |   | | └─Token(Identifier) |enabled|
-//@[017:00018) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[019:00023) |   |   |   |   |   | └─BooleanLiteralSyntax
-//@[019:00023) |   |   |   |   |   |   └─Token(TrueKeyword) |true|
-//@[023:00025) |   |   |   |   |   ├─Token(NewLine) |\r\n|
         }
-//@[008:00009) |   |   |   |   |   └─Token(RightBrace) |}|
-//@[009:00011) |   |   |   |   ├─Token(NewLine) |\r\n|
       }
-//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
-//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
     }
-//@[004:00005) |   |   |   └─Token(RightBrace) |}|
-//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
   kind: 'StorageV2'
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |kind|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00019) |   | └─StringSyntax
-//@[008:00019) |   |   └─Token(StringComplete) |'StorageV2'|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   sku: {
-//@[002:00039) |   ├─ObjectPropertySyntax
-//@[002:00005) |   | ├─IdentifierSyntax
-//@[002:00005) |   | | └─Token(Identifier) |sku|
-//@[005:00006) |   | ├─Token(Colon) |:|
-//@[007:00039) |   | └─ObjectSyntax
-//@[007:00008) |   |   ├─Token(LeftBrace) |{|
-//@[008:00010) |   |   ├─Token(NewLine) |\r\n|
     name: 'Standard_LRS'
-//@[004:00024) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00024) |   |   | └─StringSyntax
-//@[010:00024) |   |   |   └─Token(StringComplete) |'Standard_LRS'|
-//@[024:00026) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
   dependsOn: [
-//@[002:00041) |   ├─ObjectPropertySyntax
-//@[002:00011) |   | ├─IdentifierSyntax
-//@[002:00011) |   | | └─Token(Identifier) |dependsOn|
-//@[011:00012) |   | ├─Token(Colon) |:|
-//@[013:00041) |   | └─ArraySyntax
-//@[013:00014) |   |   ├─Token(LeftSquare) |[|
-//@[014:00016) |   |   ├─Token(NewLine) |\r\n|
     myStorageAccount
-//@[004:00020) |   |   ├─ArrayItemSyntax
-//@[004:00020) |   |   | └─VariableAccessSyntax
-//@[004:00020) |   |   |   └─IdentifierSyntax
-//@[004:00020) |   |   |     └─Token(Identifier) |myStorageAccount|
-//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
   ]
-//@[002:00003) |   |   └─Token(RightSquare) |]|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 param applicationName string = 'to-do-app${uniqueString(resourceGroup().id)}'
-//@[000:00077) ├─ParameterDeclarationSyntax
-//@[000:00005) | ├─Token(Identifier) |param|
-//@[006:00021) | ├─IdentifierSyntax
-//@[006:00021) | | └─Token(Identifier) |applicationName|
-//@[022:00028) | ├─TypeVariableAccessSyntax
-//@[022:00028) | | └─IdentifierSyntax
-//@[022:00028) | |   └─Token(Identifier) |string|
-//@[029:00077) | └─ParameterDefaultValueSyntax
-//@[029:00030) |   ├─Token(Assignment) |=|
-//@[031:00077) |   └─StringSyntax
-//@[031:00043) |     ├─Token(StringLeftPiece) |'to-do-app${|
-//@[043:00075) |     ├─FunctionCallSyntax
-//@[043:00055) |     | ├─IdentifierSyntax
-//@[043:00055) |     | | └─Token(Identifier) |uniqueString|
-//@[055:00056) |     | ├─Token(LeftParen) |(|
-//@[056:00074) |     | ├─FunctionArgumentSyntax
-//@[056:00074) |     | | └─PropertyAccessSyntax
-//@[056:00071) |     | |   ├─FunctionCallSyntax
-//@[056:00069) |     | |   | ├─IdentifierSyntax
-//@[056:00069) |     | |   | | └─Token(Identifier) |resourceGroup|
-//@[069:00070) |     | |   | ├─Token(LeftParen) |(|
-//@[070:00071) |     | |   | └─Token(RightParen) |)|
-//@[071:00072) |     | |   ├─Token(Dot) |.|
-//@[072:00074) |     | |   └─IdentifierSyntax
-//@[072:00074) |     | |     └─Token(Identifier) |id|
-//@[074:00075) |     | └─Token(RightParen) |)|
-//@[075:00077) |     └─Token(StringRightPiece) |}'|
-//@[077:00079) ├─Token(NewLine) |\r\n|
 var hostingPlanName = applicationName // why not just use the param directly?
-//@[000:00037) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00019) | ├─IdentifierSyntax
-//@[004:00019) | | └─Token(Identifier) |hostingPlanName|
-//@[020:00021) | ├─Token(Assignment) |=|
-//@[022:00037) | └─VariableAccessSyntax
-//@[022:00037) |   └─IdentifierSyntax
-//@[022:00037) |     └─Token(Identifier) |applicationName|
-//@[077:00081) ├─Token(NewLine) |\r\n\r\n|
 
 param appServicePlanTier string
-//@[000:00031) ├─ParameterDeclarationSyntax
-//@[000:00005) | ├─Token(Identifier) |param|
-//@[006:00024) | ├─IdentifierSyntax
-//@[006:00024) | | └─Token(Identifier) |appServicePlanTier|
-//@[025:00031) | └─TypeVariableAccessSyntax
-//@[025:00031) |   └─IdentifierSyntax
-//@[025:00031) |     └─Token(Identifier) |string|
-//@[031:00033) ├─Token(NewLine) |\r\n|
 param appServicePlanInstances int
-//@[000:00033) ├─ParameterDeclarationSyntax
-//@[000:00005) | ├─Token(Identifier) |param|
-//@[006:00029) | ├─IdentifierSyntax
-//@[006:00029) | | └─Token(Identifier) |appServicePlanInstances|
-//@[030:00033) | └─TypeVariableAccessSyntax
-//@[030:00033) |   └─IdentifierSyntax
-//@[030:00033) |     └─Token(Identifier) |int|
-//@[033:00037) ├─Token(NewLine) |\r\n\r\n|
 
 var location = resourceGroup().location
-//@[000:00039) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00012) | ├─IdentifierSyntax
-//@[004:00012) | | └─Token(Identifier) |location|
-//@[013:00014) | ├─Token(Assignment) |=|
-//@[015:00039) | └─PropertyAccessSyntax
-//@[015:00030) |   ├─FunctionCallSyntax
-//@[015:00028) |   | ├─IdentifierSyntax
-//@[015:00028) |   | | └─Token(Identifier) |resourceGroup|
-//@[028:00029) |   | ├─Token(LeftParen) |(|
-//@[029:00030) |   | └─Token(RightParen) |)|
-//@[030:00031) |   ├─Token(Dot) |.|
-//@[031:00039) |   └─IdentifierSyntax
-//@[031:00039) |     └─Token(Identifier) |location|
-//@[039:00043) ├─Token(NewLine) |\r\n\r\n|
 
 resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
-//@[000:00371) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00013) | ├─IdentifierSyntax
-//@[009:00013) | | └─Token(Identifier) |farm|
-//@[014:00052) | ├─StringSyntax
-//@[014:00052) | | └─Token(StringComplete) |'Microsoft.Web/serverFarms@2019-08-01'|
-//@[053:00054) | ├─Token(Assignment) |=|
-//@[055:00371) | └─ObjectSyntax
-//@[055:00056) |   ├─Token(LeftBrace) |{|
-//@[056:00058) |   ├─Token(NewLine) |\r\n|
   // dependsOn: resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosAccountName)
-//@[086:00088) |   ├─Token(NewLine) |\r\n|
   name: hostingPlanName
-//@[002:00023) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00023) |   | └─VariableAccessSyntax
-//@[008:00023) |   |   └─IdentifierSyntax
-//@[008:00023) |   |     └─Token(Identifier) |hostingPlanName|
-//@[023:00025) |   ├─Token(NewLine) |\r\n|
   location: location
-//@[002:00020) |   ├─ObjectPropertySyntax
-//@[002:00010) |   | ├─IdentifierSyntax
-//@[002:00010) |   | | └─Token(Identifier) |location|
-//@[010:00011) |   | ├─Token(Colon) |:|
-//@[012:00020) |   | └─VariableAccessSyntax
-//@[012:00020) |   |   └─IdentifierSyntax
-//@[012:00020) |   |     └─Token(Identifier) |location|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
   sku: {
-//@[002:00082) |   ├─ObjectPropertySyntax
-//@[002:00005) |   | ├─IdentifierSyntax
-//@[002:00005) |   | | └─Token(Identifier) |sku|
-//@[005:00006) |   | ├─Token(Colon) |:|
-//@[007:00082) |   | └─ObjectSyntax
-//@[007:00008) |   |   ├─Token(LeftBrace) |{|
-//@[008:00010) |   |   ├─Token(NewLine) |\r\n|
     name: appServicePlanTier
-//@[004:00028) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00028) |   |   | └─VariableAccessSyntax
-//@[010:00028) |   |   |   └─IdentifierSyntax
-//@[010:00028) |   |   |     └─Token(Identifier) |appServicePlanTier|
-//@[028:00030) |   |   ├─Token(NewLine) |\r\n|
     capacity: appServicePlanInstances
-//@[004:00037) |   |   ├─ObjectPropertySyntax
-//@[004:00012) |   |   | ├─IdentifierSyntax
-//@[004:00012) |   |   | | └─Token(Identifier) |capacity|
-//@[012:00013) |   |   | ├─Token(Colon) |:|
-//@[014:00037) |   |   | └─VariableAccessSyntax
-//@[014:00037) |   |   |   └─IdentifierSyntax
-//@[014:00037) |   |   |     └─Token(Identifier) |appServicePlanInstances|
-//@[037:00039) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00091) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00091) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     name: hostingPlanName // just hostingPlanName results in an error
-//@[004:00025) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00025) |   |   | └─VariableAccessSyntax
-//@[010:00025) |   |   |   └─IdentifierSyntax
-//@[010:00025) |   |   |     └─Token(Identifier) |hostingPlanName|
-//@[069:00071) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
-//@[000:00107) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00022) | ├─IdentifierSyntax
-//@[004:00022) | | └─Token(Identifier) |cosmosDbResourceId|
-//@[023:00024) | ├─Token(Assignment) |=|
-//@[025:00107) | └─FunctionCallSyntax
-//@[025:00035) |   ├─IdentifierSyntax
-//@[025:00035) |   | └─Token(Identifier) |resourceId|
-//@[035:00036) |   ├─Token(LeftParen) |(|
-//@[036:00075) |   ├─FunctionArgumentSyntax
-//@[036:00075) |   | └─StringSyntax
-//@[036:00075) |   |   └─Token(StringComplete) |'Microsoft.DocumentDB/databaseAccounts'|
-//@[075:00076) |   ├─Token(Comma) |,|
-//@[076:00078) |   ├─Token(NewLine) |\r\n|
 // comment
-//@[010:00012) |   ├─Token(NewLine) |\r\n|
 cosmosDb.account)
-//@[000:00016) |   ├─FunctionArgumentSyntax
-//@[000:00016) |   | └─PropertyAccessSyntax
-//@[000:00008) |   |   ├─VariableAccessSyntax
-//@[000:00008) |   |   | └─IdentifierSyntax
-//@[000:00008) |   |   |   └─Token(Identifier) |cosmosDb|
-//@[008:00009) |   |   ├─Token(Dot) |.|
-//@[009:00016) |   |   └─IdentifierSyntax
-//@[009:00016) |   |     └─Token(Identifier) |account|
-//@[016:00017) |   └─Token(RightParen) |)|
-//@[017:00019) ├─Token(NewLine) |\r\n|
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
-//@[000:00064) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00015) | ├─IdentifierSyntax
-//@[004:00015) | | └─Token(Identifier) |cosmosDbRef|
-//@[016:00017) | ├─Token(Assignment) |=|
-//@[018:00064) | └─PropertyAccessSyntax
-//@[018:00047) |   ├─FunctionCallSyntax
-//@[018:00027) |   | ├─IdentifierSyntax
-//@[018:00027) |   | | └─Token(Identifier) |reference|
-//@[027:00028) |   | ├─Token(LeftParen) |(|
-//@[028:00046) |   | ├─FunctionArgumentSyntax
-//@[028:00046) |   | | └─VariableAccessSyntax
-//@[028:00046) |   | |   └─IdentifierSyntax
-//@[028:00046) |   | |     └─Token(Identifier) |cosmosDbResourceId|
-//@[046:00047) |   | └─Token(RightParen) |)|
-//@[047:00048) |   ├─Token(Dot) |.|
-//@[048:00064) |   └─IdentifierSyntax
-//@[048:00064) |     └─Token(Identifier) |documentEndpoint|
-//@[064:00068) ├─Token(NewLine) |\r\n\r\n|
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference
-//@[094:00096) ├─Token(NewLine) |\r\n|
 // it should not be present at all in the template output as there is nowhere logical to put it
-//@[095:00097) ├─Token(NewLine) |\r\n|
 var cosmosDbEndpoint = cosmosDbRef.documentEndpoint
-//@[000:00051) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00020) | ├─IdentifierSyntax
-//@[004:00020) | | └─Token(Identifier) |cosmosDbEndpoint|
-//@[021:00022) | ├─Token(Assignment) |=|
-//@[023:00051) | └─PropertyAccessSyntax
-//@[023:00034) |   ├─VariableAccessSyntax
-//@[023:00034) |   | └─IdentifierSyntax
-//@[023:00034) |   |   └─Token(Identifier) |cosmosDbRef|
-//@[034:00035) |   ├─Token(Dot) |.|
-//@[035:00051) |   └─IdentifierSyntax
-//@[035:00051) |     └─Token(Identifier) |documentEndpoint|
-//@[051:00055) ├─Token(NewLine) |\r\n\r\n|
 
 param webSiteName string
-//@[000:00024) ├─ParameterDeclarationSyntax
-//@[000:00005) | ├─Token(Identifier) |param|
-//@[006:00017) | ├─IdentifierSyntax
-//@[006:00017) | | └─Token(Identifier) |webSiteName|
-//@[018:00024) | └─TypeVariableAccessSyntax
-//@[018:00024) |   └─IdentifierSyntax
-//@[018:00024) |     └─Token(Identifier) |string|
-//@[024:00026) ├─Token(NewLine) |\r\n|
 param cosmosDb object
-//@[000:00021) ├─ParameterDeclarationSyntax
-//@[000:00005) | ├─Token(Identifier) |param|
-//@[006:00014) | ├─IdentifierSyntax
-//@[006:00014) | | └─Token(Identifier) |cosmosDb|
-//@[015:00021) | └─TypeVariableAccessSyntax
-//@[015:00021) |   └─IdentifierSyntax
-//@[015:00021) |     └─Token(Identifier) |object|
-//@[021:00023) ├─Token(NewLine) |\r\n|
 resource site 'Microsoft.Web/sites@2019-08-01' = {
-//@[000:00689) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00013) | ├─IdentifierSyntax
-//@[009:00013) | | └─Token(Identifier) |site|
-//@[014:00046) | ├─StringSyntax
-//@[014:00046) | | └─Token(StringComplete) |'Microsoft.Web/sites@2019-08-01'|
-//@[047:00048) | ├─Token(Assignment) |=|
-//@[049:00689) | └─ObjectSyntax
-//@[049:00050) |   ├─Token(LeftBrace) |{|
-//@[050:00052) |   ├─Token(NewLine) |\r\n|
   name: webSiteName
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00019) |   | └─VariableAccessSyntax
-//@[008:00019) |   |   └─IdentifierSyntax
-//@[008:00019) |   |     └─Token(Identifier) |webSiteName|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   location: location
-//@[002:00020) |   ├─ObjectPropertySyntax
-//@[002:00010) |   | ├─IdentifierSyntax
-//@[002:00010) |   | | └─Token(Identifier) |location|
-//@[010:00011) |   | ├─Token(Colon) |:|
-//@[012:00020) |   | └─VariableAccessSyntax
-//@[012:00020) |   |   └─IdentifierSyntax
-//@[012:00020) |   |     └─Token(Identifier) |location|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00591) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00591) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     // not yet supported // serverFarmId: farm.id
-//@[049:00051) |   |   ├─Token(NewLine) |\r\n|
     siteConfig: {
-//@[004:00518) |   |   ├─ObjectPropertySyntax
-//@[004:00014) |   |   | ├─IdentifierSyntax
-//@[004:00014) |   |   | | └─Token(Identifier) |siteConfig|
-//@[014:00015) |   |   | ├─Token(Colon) |:|
-//@[016:00518) |   |   | └─ObjectSyntax
-//@[016:00017) |   |   |   ├─Token(LeftBrace) |{|
-//@[017:00019) |   |   |   ├─Token(NewLine) |\r\n|
       appSettings: [
-//@[006:00492) |   |   |   ├─ObjectPropertySyntax
-//@[006:00017) |   |   |   | ├─IdentifierSyntax
-//@[006:00017) |   |   |   | | └─Token(Identifier) |appSettings|
-//@[017:00018) |   |   |   | ├─Token(Colon) |:|
-//@[019:00492) |   |   |   | └─ArraySyntax
-//@[019:00020) |   |   |   |   ├─Token(LeftSquare) |[|
-//@[020:00022) |   |   |   |   ├─Token(NewLine) |\r\n|
         {
-//@[008:00121) |   |   |   |   ├─ArrayItemSyntax
-//@[008:00121) |   |   |   |   | └─ObjectSyntax
-//@[008:00009) |   |   |   |   |   ├─Token(LeftBrace) |{|
-//@[009:00011) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           name: 'CosmosDb:Account'
-//@[010:00034) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00014) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00014) |   |   |   |   |   | | └─Token(Identifier) |name|
-//@[014:00015) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[016:00034) |   |   |   |   |   | └─StringSyntax
-//@[016:00034) |   |   |   |   |   |   └─Token(StringComplete) |'CosmosDb:Account'|
-//@[034:00036) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           value: reference(cosmosDbResourceId).documentEndpoint
-//@[010:00063) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00015) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00015) |   |   |   |   |   | | └─Token(Identifier) |value|
-//@[015:00016) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[017:00063) |   |   |   |   |   | └─PropertyAccessSyntax
-//@[017:00046) |   |   |   |   |   |   ├─FunctionCallSyntax
-//@[017:00026) |   |   |   |   |   |   | ├─IdentifierSyntax
-//@[017:00026) |   |   |   |   |   |   | | └─Token(Identifier) |reference|
-//@[026:00027) |   |   |   |   |   |   | ├─Token(LeftParen) |(|
-//@[027:00045) |   |   |   |   |   |   | ├─FunctionArgumentSyntax
-//@[027:00045) |   |   |   |   |   |   | | └─VariableAccessSyntax
-//@[027:00045) |   |   |   |   |   |   | |   └─IdentifierSyntax
-//@[027:00045) |   |   |   |   |   |   | |     └─Token(Identifier) |cosmosDbResourceId|
-//@[045:00046) |   |   |   |   |   |   | └─Token(RightParen) |)|
-//@[046:00047) |   |   |   |   |   |   ├─Token(Dot) |.|
-//@[047:00063) |   |   |   |   |   |   └─IdentifierSyntax
-//@[047:00063) |   |   |   |   |   |     └─Token(Identifier) |documentEndpoint|
-//@[063:00065) |   |   |   |   |   ├─Token(NewLine) |\r\n|
         }
-//@[008:00009) |   |   |   |   |   └─Token(RightBrace) |}|
-//@[009:00011) |   |   |   |   ├─Token(NewLine) |\r\n|
         {
-//@[008:00130) |   |   |   |   ├─ArrayItemSyntax
-//@[008:00130) |   |   |   |   | └─ObjectSyntax
-//@[008:00009) |   |   |   |   |   ├─Token(LeftBrace) |{|
-//@[009:00011) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           name: 'CosmosDb:Key'
-//@[010:00030) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00014) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00014) |   |   |   |   |   | | └─Token(Identifier) |name|
-//@[014:00015) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[016:00030) |   |   |   |   |   | └─StringSyntax
-//@[016:00030) |   |   |   |   |   |   └─Token(StringComplete) |'CosmosDb:Key'|
-//@[030:00032) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           value: listKeys(cosmosDbResourceId, '2020-04-01').primaryMasterKey
-//@[010:00076) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00015) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00015) |   |   |   |   |   | | └─Token(Identifier) |value|
-//@[015:00016) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[017:00076) |   |   |   |   |   | └─PropertyAccessSyntax
-//@[017:00059) |   |   |   |   |   |   ├─FunctionCallSyntax
-//@[017:00025) |   |   |   |   |   |   | ├─IdentifierSyntax
-//@[017:00025) |   |   |   |   |   |   | | └─Token(Identifier) |listKeys|
-//@[025:00026) |   |   |   |   |   |   | ├─Token(LeftParen) |(|
-//@[026:00044) |   |   |   |   |   |   | ├─FunctionArgumentSyntax
-//@[026:00044) |   |   |   |   |   |   | | └─VariableAccessSyntax
-//@[026:00044) |   |   |   |   |   |   | |   └─IdentifierSyntax
-//@[026:00044) |   |   |   |   |   |   | |     └─Token(Identifier) |cosmosDbResourceId|
-//@[044:00045) |   |   |   |   |   |   | ├─Token(Comma) |,|
-//@[046:00058) |   |   |   |   |   |   | ├─FunctionArgumentSyntax
-//@[046:00058) |   |   |   |   |   |   | | └─StringSyntax
-//@[046:00058) |   |   |   |   |   |   | |   └─Token(StringComplete) |'2020-04-01'|
-//@[058:00059) |   |   |   |   |   |   | └─Token(RightParen) |)|
-//@[059:00060) |   |   |   |   |   |   ├─Token(Dot) |.|
-//@[060:00076) |   |   |   |   |   |   └─IdentifierSyntax
-//@[060:00076) |   |   |   |   |   |     └─Token(Identifier) |primaryMasterKey|
-//@[076:00078) |   |   |   |   |   ├─Token(NewLine) |\r\n|
         }
-//@[008:00009) |   |   |   |   |   └─Token(RightBrace) |}|
-//@[009:00011) |   |   |   |   ├─Token(NewLine) |\r\n|
         {
-//@[008:00101) |   |   |   |   ├─ArrayItemSyntax
-//@[008:00101) |   |   |   |   | └─ObjectSyntax
-//@[008:00009) |   |   |   |   |   ├─Token(LeftBrace) |{|
-//@[009:00011) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           name: 'CosmosDb:DatabaseName'
-//@[010:00039) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00014) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00014) |   |   |   |   |   | | └─Token(Identifier) |name|
-//@[014:00015) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[016:00039) |   |   |   |   |   | └─StringSyntax
-//@[016:00039) |   |   |   |   |   |   └─Token(StringComplete) |'CosmosDb:DatabaseName'|
-//@[039:00041) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           value: cosmosDb.databaseName
-//@[010:00038) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00015) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00015) |   |   |   |   |   | | └─Token(Identifier) |value|
-//@[015:00016) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[017:00038) |   |   |   |   |   | └─PropertyAccessSyntax
-//@[017:00025) |   |   |   |   |   |   ├─VariableAccessSyntax
-//@[017:00025) |   |   |   |   |   |   | └─IdentifierSyntax
-//@[017:00025) |   |   |   |   |   |   |   └─Token(Identifier) |cosmosDb|
-//@[025:00026) |   |   |   |   |   |   ├─Token(Dot) |.|
-//@[026:00038) |   |   |   |   |   |   └─IdentifierSyntax
-//@[026:00038) |   |   |   |   |   |     └─Token(Identifier) |databaseName|
-//@[038:00040) |   |   |   |   |   ├─Token(NewLine) |\r\n|
         }
-//@[008:00009) |   |   |   |   |   └─Token(RightBrace) |}|
-//@[009:00011) |   |   |   |   ├─Token(NewLine) |\r\n|
         {
-//@[008:00103) |   |   |   |   ├─ArrayItemSyntax
-//@[008:00103) |   |   |   |   | └─ObjectSyntax
-//@[008:00009) |   |   |   |   |   ├─Token(LeftBrace) |{|
-//@[009:00011) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           name: 'CosmosDb:ContainerName'
-//@[010:00040) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00014) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00014) |   |   |   |   |   | | └─Token(Identifier) |name|
-//@[014:00015) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[016:00040) |   |   |   |   |   | └─StringSyntax
-//@[016:00040) |   |   |   |   |   |   └─Token(StringComplete) |'CosmosDb:ContainerName'|
-//@[040:00042) |   |   |   |   |   ├─Token(NewLine) |\r\n|
           value: cosmosDb.containerName
-//@[010:00039) |   |   |   |   |   ├─ObjectPropertySyntax
-//@[010:00015) |   |   |   |   |   | ├─IdentifierSyntax
-//@[010:00015) |   |   |   |   |   | | └─Token(Identifier) |value|
-//@[015:00016) |   |   |   |   |   | ├─Token(Colon) |:|
-//@[017:00039) |   |   |   |   |   | └─PropertyAccessSyntax
-//@[017:00025) |   |   |   |   |   |   ├─VariableAccessSyntax
-//@[017:00025) |   |   |   |   |   |   | └─IdentifierSyntax
-//@[017:00025) |   |   |   |   |   |   |   └─Token(Identifier) |cosmosDb|
-//@[025:00026) |   |   |   |   |   |   ├─Token(Dot) |.|
-//@[026:00039) |   |   |   |   |   |   └─IdentifierSyntax
-//@[026:00039) |   |   |   |   |   |     └─Token(Identifier) |containerName|
-//@[039:00041) |   |   |   |   |   ├─Token(NewLine) |\r\n|
         }
-//@[008:00009) |   |   |   |   |   └─Token(RightBrace) |}|
-//@[009:00011) |   |   |   |   ├─Token(NewLine) |\r\n|
       ]
-//@[006:00007) |   |   |   |   └─Token(RightSquare) |]|
-//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
     }
-//@[004:00005) |   |   |   └─Token(RightBrace) |}|
-//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 var _siteApiVersion = site.apiVersion
-//@[000:00037) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00019) | ├─IdentifierSyntax
-//@[004:00019) | | └─Token(Identifier) |_siteApiVersion|
-//@[020:00021) | ├─Token(Assignment) |=|
-//@[022:00037) | └─PropertyAccessSyntax
-//@[022:00026) |   ├─VariableAccessSyntax
-//@[022:00026) |   | └─IdentifierSyntax
-//@[022:00026) |   |   └─Token(Identifier) |site|
-//@[026:00027) |   ├─Token(Dot) |.|
-//@[027:00037) |   └─IdentifierSyntax
-//@[027:00037) |     └─Token(Identifier) |apiVersion|
-//@[037:00039) ├─Token(NewLine) |\r\n|
 var _siteType = site.type
-//@[000:00025) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00013) | ├─IdentifierSyntax
-//@[004:00013) | | └─Token(Identifier) |_siteType|
-//@[014:00015) | ├─Token(Assignment) |=|
-//@[016:00025) | └─PropertyAccessSyntax
-//@[016:00020) |   ├─VariableAccessSyntax
-//@[016:00020) |   | └─IdentifierSyntax
-//@[016:00020) |   |   └─Token(Identifier) |site|
-//@[020:00021) |   ├─Token(Dot) |.|
-//@[021:00025) |   └─IdentifierSyntax
-//@[021:00025) |     └─Token(Identifier) |type|
-//@[025:00029) ├─Token(NewLine) |\r\n\r\n|
 
 output siteApiVersion string = site.apiVersion
-//@[000:00046) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00021) | ├─IdentifierSyntax
-//@[007:00021) | | └─Token(Identifier) |siteApiVersion|
-//@[022:00028) | ├─TypeVariableAccessSyntax
-//@[022:00028) | | └─IdentifierSyntax
-//@[022:00028) | |   └─Token(Identifier) |string|
-//@[029:00030) | ├─Token(Assignment) |=|
-//@[031:00046) | └─PropertyAccessSyntax
-//@[031:00035) |   ├─VariableAccessSyntax
-//@[031:00035) |   | └─IdentifierSyntax
-//@[031:00035) |   |   └─Token(Identifier) |site|
-//@[035:00036) |   ├─Token(Dot) |.|
-//@[036:00046) |   └─IdentifierSyntax
-//@[036:00046) |     └─Token(Identifier) |apiVersion|
-//@[046:00048) ├─Token(NewLine) |\r\n|
 output siteType string = site.type
-//@[000:00034) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00015) | ├─IdentifierSyntax
-//@[007:00015) | | └─Token(Identifier) |siteType|
-//@[016:00022) | ├─TypeVariableAccessSyntax
-//@[016:00022) | | └─IdentifierSyntax
-//@[016:00022) | |   └─Token(Identifier) |string|
-//@[023:00024) | ├─Token(Assignment) |=|
-//@[025:00034) | └─PropertyAccessSyntax
-//@[025:00029) |   ├─VariableAccessSyntax
-//@[025:00029) |   | └─IdentifierSyntax
-//@[025:00029) |   |   └─Token(Identifier) |site|
-//@[029:00030) |   ├─Token(Dot) |.|
-//@[030:00034) |   └─IdentifierSyntax
-//@[030:00034) |     └─Token(Identifier) |type|
-//@[034:00038) ├─Token(NewLine) |\r\n\r\n|
 
 resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
-//@[000:00354) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00015) | ├─IdentifierSyntax
-//@[009:00015) | | └─Token(Identifier) |nested|
-//@[016:00060) | ├─StringSyntax
-//@[016:00060) | | └─Token(StringComplete) |'Microsoft.Resources/deployments@2019-10-01'|
-//@[061:00062) | ├─Token(Assignment) |=|
-//@[063:00354) | └─ObjectSyntax
-//@[063:00064) |   ├─Token(LeftBrace) |{|
-//@[064:00066) |   ├─Token(NewLine) |\r\n|
   name: 'nestedTemplate1'
-//@[002:00025) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00025) |   | └─StringSyntax
-//@[008:00025) |   |   └─Token(StringComplete) |'nestedTemplate1'|
-//@[025:00027) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00258) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00258) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     mode: 'Incremental'
-//@[004:00023) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |mode|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00023) |   |   | └─StringSyntax
-//@[010:00023) |   |   |   └─Token(StringComplete) |'Incremental'|
-//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
     template: {
-//@[004:00211) |   |   ├─ObjectPropertySyntax
-//@[004:00012) |   |   | ├─IdentifierSyntax
-//@[004:00012) |   |   | | └─Token(Identifier) |template|
-//@[012:00013) |   |   | ├─Token(Colon) |:|
-//@[014:00211) |   |   | └─ObjectSyntax
-//@[014:00015) |   |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   |   ├─Token(NewLine) |\r\n|
       // string key value
-//@[025:00027) |   |   |   ├─Token(NewLine) |\r\n|
       '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-//@[006:00098) |   |   |   ├─ObjectPropertySyntax
-//@[006:00015) |   |   |   | ├─StringSyntax
-//@[006:00015) |   |   |   | | └─Token(StringComplete) |'$schema'|
-//@[015:00016) |   |   |   | ├─Token(Colon) |:|
-//@[017:00098) |   |   |   | └─StringSyntax
-//@[017:00098) |   |   |   |   └─Token(StringComplete) |'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'|
-//@[098:00100) |   |   |   ├─Token(NewLine) |\r\n|
       contentVersion: '1.0.0.0'
-//@[006:00031) |   |   |   ├─ObjectPropertySyntax
-//@[006:00020) |   |   |   | ├─IdentifierSyntax
-//@[006:00020) |   |   |   | | └─Token(Identifier) |contentVersion|
-//@[020:00021) |   |   |   | ├─Token(Colon) |:|
-//@[022:00031) |   |   |   | └─StringSyntax
-//@[022:00031) |   |   |   |   └─Token(StringComplete) |'1.0.0.0'|
-//@[031:00033) |   |   |   ├─Token(NewLine) |\r\n|
       resources: [
-//@[006:00027) |   |   |   ├─ObjectPropertySyntax
-//@[006:00015) |   |   |   | ├─IdentifierSyntax
-//@[006:00015) |   |   |   | | └─Token(Identifier) |resources|
-//@[015:00016) |   |   |   | ├─Token(Colon) |:|
-//@[017:00027) |   |   |   | └─ArraySyntax
-//@[017:00018) |   |   |   |   ├─Token(LeftSquare) |[|
-//@[018:00020) |   |   |   |   ├─Token(NewLine) |\r\n|
       ]
-//@[006:00007) |   |   |   |   └─Token(RightSquare) |]|
-//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
     }
-//@[004:00005) |   |   |   └─Token(RightBrace) |}|
-//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 // should be able to access the read only properties
-//@[052:00054) ├─Token(NewLine) |\r\n|
 resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
-//@[000:00284) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00036) | ├─IdentifierSyntax
-//@[009:00036) | | └─Token(Identifier) |accessingReadOnlyProperties|
-//@[037:00068) | ├─StringSyntax
-//@[037:00068) | | └─Token(StringComplete) |'Microsoft.Foo/foos@2019-10-01'|
-//@[069:00070) | ├─Token(Assignment) |=|
-//@[071:00284) | └─ObjectSyntax
-//@[071:00072) |   ├─Token(LeftBrace) |{|
-//@[072:00074) |   ├─Token(NewLine) |\r\n|
   name: 'nestedTemplate1'
-//@[002:00025) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00025) |   | └─StringSyntax
-//@[008:00025) |   |   └─Token(StringComplete) |'nestedTemplate1'|
-//@[025:00027) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00180) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00180) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     otherId: nested.id
-//@[004:00022) |   |   ├─ObjectPropertySyntax
-//@[004:00011) |   |   | ├─IdentifierSyntax
-//@[004:00011) |   |   | | └─Token(Identifier) |otherId|
-//@[011:00012) |   |   | ├─Token(Colon) |:|
-//@[013:00022) |   |   | └─PropertyAccessSyntax
-//@[013:00019) |   |   |   ├─VariableAccessSyntax
-//@[013:00019) |   |   |   | └─IdentifierSyntax
-//@[013:00019) |   |   |   |   └─Token(Identifier) |nested|
-//@[019:00020) |   |   |   ├─Token(Dot) |.|
-//@[020:00022) |   |   |   └─IdentifierSyntax
-//@[020:00022) |   |   |     └─Token(Identifier) |id|
-//@[022:00024) |   |   ├─Token(NewLine) |\r\n|
     otherName: nested.name
-//@[004:00026) |   |   ├─ObjectPropertySyntax
-//@[004:00013) |   |   | ├─IdentifierSyntax
-//@[004:00013) |   |   | | └─Token(Identifier) |otherName|
-//@[013:00014) |   |   | ├─Token(Colon) |:|
-//@[015:00026) |   |   | └─PropertyAccessSyntax
-//@[015:00021) |   |   |   ├─VariableAccessSyntax
-//@[015:00021) |   |   |   | └─IdentifierSyntax
-//@[015:00021) |   |   |   |   └─Token(Identifier) |nested|
-//@[021:00022) |   |   |   ├─Token(Dot) |.|
-//@[022:00026) |   |   |   └─IdentifierSyntax
-//@[022:00026) |   |   |     └─Token(Identifier) |name|
-//@[026:00028) |   |   ├─Token(NewLine) |\r\n|
     otherVersion: nested.apiVersion
-//@[004:00035) |   |   ├─ObjectPropertySyntax
-//@[004:00016) |   |   | ├─IdentifierSyntax
-//@[004:00016) |   |   | | └─Token(Identifier) |otherVersion|
-//@[016:00017) |   |   | ├─Token(Colon) |:|
-//@[018:00035) |   |   | └─PropertyAccessSyntax
-//@[018:00024) |   |   |   ├─VariableAccessSyntax
-//@[018:00024) |   |   |   | └─IdentifierSyntax
-//@[018:00024) |   |   |   |   └─Token(Identifier) |nested|
-//@[024:00025) |   |   |   ├─Token(Dot) |.|
-//@[025:00035) |   |   |   └─IdentifierSyntax
-//@[025:00035) |   |   |     └─Token(Identifier) |apiVersion|
-//@[035:00037) |   |   ├─Token(NewLine) |\r\n|
     otherType: nested.type
-//@[004:00026) |   |   ├─ObjectPropertySyntax
-//@[004:00013) |   |   | ├─IdentifierSyntax
-//@[004:00013) |   |   | | └─Token(Identifier) |otherType|
-//@[013:00014) |   |   | ├─Token(Colon) |:|
-//@[015:00026) |   |   | └─PropertyAccessSyntax
-//@[015:00021) |   |   |   ├─VariableAccessSyntax
-//@[015:00021) |   |   |   | └─IdentifierSyntax
-//@[015:00021) |   |   |   |   └─Token(Identifier) |nested|
-//@[021:00022) |   |   |   ├─Token(Dot) |.|
-//@[022:00026) |   |   |   └─IdentifierSyntax
-//@[022:00026) |   |   |     └─Token(Identifier) |type|
-//@[026:00030) |   |   ├─Token(NewLine) |\r\n\r\n|
 
     otherThings: nested.properties.mode
-//@[004:00039) |   |   ├─ObjectPropertySyntax
-//@[004:00015) |   |   | ├─IdentifierSyntax
-//@[004:00015) |   |   | | └─Token(Identifier) |otherThings|
-//@[015:00016) |   |   | ├─Token(Colon) |:|
-//@[017:00039) |   |   | └─PropertyAccessSyntax
-//@[017:00034) |   |   |   ├─PropertyAccessSyntax
-//@[017:00023) |   |   |   | ├─VariableAccessSyntax
-//@[017:00023) |   |   |   | | └─IdentifierSyntax
-//@[017:00023) |   |   |   | |   └─Token(Identifier) |nested|
-//@[023:00024) |   |   |   | ├─Token(Dot) |.|
-//@[024:00034) |   |   |   | └─IdentifierSyntax
-//@[024:00034) |   |   |   |   └─Token(Identifier) |properties|
-//@[034:00035) |   |   |   ├─Token(Dot) |.|
-//@[035:00039) |   |   |   └─IdentifierSyntax
-//@[035:00039) |   |   |     └─Token(Identifier) |mode|
-//@[039:00041) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource resourceA 'My.Rp/typeA@2020-01-01' = {
-//@[000:00071) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |resourceA|
-//@[019:00043) | ├─StringSyntax
-//@[019:00043) | | └─Token(StringComplete) |'My.Rp/typeA@2020-01-01'|
-//@[044:00045) | ├─Token(Assignment) |=|
-//@[046:00071) | └─ObjectSyntax
-//@[046:00047) |   ├─Token(LeftBrace) |{|
-//@[047:00049) |   ├─Token(NewLine) |\r\n|
   name: 'resourceA'
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00019) |   | └─StringSyntax
-//@[008:00019) |   |   └─Token(StringComplete) |'resourceA'|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource resourceB 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[000:00092) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |resourceB|
-//@[019:00049) | ├─StringSyntax
-//@[019:00049) | | └─Token(StringComplete) |'My.Rp/typeA/typeB@2020-01-01'|
-//@[050:00051) | ├─Token(Assignment) |=|
-//@[052:00092) | └─ObjectSyntax
-//@[052:00053) |   ├─Token(LeftBrace) |{|
-//@[053:00055) |   ├─Token(NewLine) |\r\n|
   name: '${resourceA.name}/myName'
-//@[002:00034) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00034) |   | └─StringSyntax
-//@[008:00011) |   |   ├─Token(StringLeftPiece) |'${|
-//@[011:00025) |   |   ├─PropertyAccessSyntax
-//@[011:00020) |   |   | ├─VariableAccessSyntax
-//@[011:00020) |   |   | | └─IdentifierSyntax
-//@[011:00020) |   |   | |   └─Token(Identifier) |resourceA|
-//@[020:00021) |   |   | ├─Token(Dot) |.|
-//@[021:00025) |   |   | └─IdentifierSyntax
-//@[021:00025) |   |   |   └─Token(Identifier) |name|
-//@[025:00034) |   |   └─Token(StringRightPiece) |}/myName'|
-//@[034:00036) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[000:00269) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |resourceC|
-//@[019:00049) | ├─StringSyntax
-//@[019:00049) | | └─Token(StringComplete) |'My.Rp/typeA/typeB@2020-01-01'|
-//@[050:00051) | ├─Token(Assignment) |=|
-//@[052:00269) | └─ObjectSyntax
-//@[052:00053) |   ├─Token(LeftBrace) |{|
-//@[053:00055) |   ├─Token(NewLine) |\r\n|
   name: '${resourceA.name}/myName'
-//@[002:00034) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00034) |   | └─StringSyntax
-//@[008:00011) |   |   ├─Token(StringLeftPiece) |'${|
-//@[011:00025) |   |   ├─PropertyAccessSyntax
-//@[011:00020) |   |   | ├─VariableAccessSyntax
-//@[011:00020) |   |   | | └─IdentifierSyntax
-//@[011:00020) |   |   | |   └─Token(Identifier) |resourceA|
-//@[020:00021) |   |   | ├─Token(Dot) |.|
-//@[021:00025) |   |   | └─IdentifierSyntax
-//@[021:00025) |   |   |   └─Token(Identifier) |name|
-//@[025:00034) |   |   └─Token(StringRightPiece) |}/myName'|
-//@[034:00036) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00175) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00175) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     aId: resourceA.id
-//@[004:00021) |   |   ├─ObjectPropertySyntax
-//@[004:00007) |   |   | ├─IdentifierSyntax
-//@[004:00007) |   |   | | └─Token(Identifier) |aId|
-//@[007:00008) |   |   | ├─Token(Colon) |:|
-//@[009:00021) |   |   | └─PropertyAccessSyntax
-//@[009:00018) |   |   |   ├─VariableAccessSyntax
-//@[009:00018) |   |   |   | └─IdentifierSyntax
-//@[009:00018) |   |   |   |   └─Token(Identifier) |resourceA|
-//@[018:00019) |   |   |   ├─Token(Dot) |.|
-//@[019:00021) |   |   |   └─IdentifierSyntax
-//@[019:00021) |   |   |     └─Token(Identifier) |id|
-//@[021:00023) |   |   ├─Token(NewLine) |\r\n|
     aType: resourceA.type
-//@[004:00025) |   |   ├─ObjectPropertySyntax
-//@[004:00009) |   |   | ├─IdentifierSyntax
-//@[004:00009) |   |   | | └─Token(Identifier) |aType|
-//@[009:00010) |   |   | ├─Token(Colon) |:|
-//@[011:00025) |   |   | └─PropertyAccessSyntax
-//@[011:00020) |   |   |   ├─VariableAccessSyntax
-//@[011:00020) |   |   |   | └─IdentifierSyntax
-//@[011:00020) |   |   |   |   └─Token(Identifier) |resourceA|
-//@[020:00021) |   |   |   ├─Token(Dot) |.|
-//@[021:00025) |   |   |   └─IdentifierSyntax
-//@[021:00025) |   |   |     └─Token(Identifier) |type|
-//@[025:00027) |   |   ├─Token(NewLine) |\r\n|
     aName: resourceA.name
-//@[004:00025) |   |   ├─ObjectPropertySyntax
-//@[004:00009) |   |   | ├─IdentifierSyntax
-//@[004:00009) |   |   | | └─Token(Identifier) |aName|
-//@[009:00010) |   |   | ├─Token(Colon) |:|
-//@[011:00025) |   |   | └─PropertyAccessSyntax
-//@[011:00020) |   |   |   ├─VariableAccessSyntax
-//@[011:00020) |   |   |   | └─IdentifierSyntax
-//@[011:00020) |   |   |   |   └─Token(Identifier) |resourceA|
-//@[020:00021) |   |   |   ├─Token(Dot) |.|
-//@[021:00025) |   |   |   └─IdentifierSyntax
-//@[021:00025) |   |   |     └─Token(Identifier) |name|
-//@[025:00027) |   |   ├─Token(NewLine) |\r\n|
     aApiVersion: resourceA.apiVersion
-//@[004:00037) |   |   ├─ObjectPropertySyntax
-//@[004:00015) |   |   | ├─IdentifierSyntax
-//@[004:00015) |   |   | | └─Token(Identifier) |aApiVersion|
-//@[015:00016) |   |   | ├─Token(Colon) |:|
-//@[017:00037) |   |   | └─PropertyAccessSyntax
-//@[017:00026) |   |   |   ├─VariableAccessSyntax
-//@[017:00026) |   |   |   | └─IdentifierSyntax
-//@[017:00026) |   |   |   |   └─Token(Identifier) |resourceA|
-//@[026:00027) |   |   |   ├─Token(Dot) |.|
-//@[027:00037) |   |   |   └─IdentifierSyntax
-//@[027:00037) |   |   |     └─Token(Identifier) |apiVersion|
-//@[037:00039) |   |   ├─Token(NewLine) |\r\n|
     bProperties: resourceB.properties
-//@[004:00037) |   |   ├─ObjectPropertySyntax
-//@[004:00015) |   |   | ├─IdentifierSyntax
-//@[004:00015) |   |   | | └─Token(Identifier) |bProperties|
-//@[015:00016) |   |   | ├─Token(Colon) |:|
-//@[017:00037) |   |   | └─PropertyAccessSyntax
-//@[017:00026) |   |   |   ├─VariableAccessSyntax
-//@[017:00026) |   |   |   | └─IdentifierSyntax
-//@[017:00026) |   |   |   |   └─Token(Identifier) |resourceB|
-//@[026:00027) |   |   |   ├─Token(Dot) |.|
-//@[027:00037) |   |   |   └─IdentifierSyntax
-//@[027:00037) |   |   |     └─Token(Identifier) |properties|
-//@[037:00039) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 var varARuntime = {
-//@[000:00155) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00015) | ├─IdentifierSyntax
-//@[004:00015) | | └─Token(Identifier) |varARuntime|
-//@[016:00017) | ├─Token(Assignment) |=|
-//@[018:00155) | └─ObjectSyntax
-//@[018:00019) |   ├─Token(LeftBrace) |{|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   bId: resourceB.id
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00005) |   | ├─IdentifierSyntax
-//@[002:00005) |   | | └─Token(Identifier) |bId|
-//@[005:00006) |   | ├─Token(Colon) |:|
-//@[007:00019) |   | └─PropertyAccessSyntax
-//@[007:00016) |   |   ├─VariableAccessSyntax
-//@[007:00016) |   |   | └─IdentifierSyntax
-//@[007:00016) |   |   |   └─Token(Identifier) |resourceB|
-//@[016:00017) |   |   ├─Token(Dot) |.|
-//@[017:00019) |   |   └─IdentifierSyntax
-//@[017:00019) |   |     └─Token(Identifier) |id|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   bType: resourceB.type
-//@[002:00023) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |bType|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00023) |   | └─PropertyAccessSyntax
-//@[009:00018) |   |   ├─VariableAccessSyntax
-//@[009:00018) |   |   | └─IdentifierSyntax
-//@[009:00018) |   |   |   └─Token(Identifier) |resourceB|
-//@[018:00019) |   |   ├─Token(Dot) |.|
-//@[019:00023) |   |   └─IdentifierSyntax
-//@[019:00023) |   |     └─Token(Identifier) |type|
-//@[023:00025) |   ├─Token(NewLine) |\r\n|
   bName: resourceB.name
-//@[002:00023) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |bName|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00023) |   | └─PropertyAccessSyntax
-//@[009:00018) |   |   ├─VariableAccessSyntax
-//@[009:00018) |   |   | └─IdentifierSyntax
-//@[009:00018) |   |   |   └─Token(Identifier) |resourceB|
-//@[018:00019) |   |   ├─Token(Dot) |.|
-//@[019:00023) |   |   └─IdentifierSyntax
-//@[019:00023) |   |     └─Token(Identifier) |name|
-//@[023:00025) |   ├─Token(NewLine) |\r\n|
   bApiVersion: resourceB.apiVersion
-//@[002:00035) |   ├─ObjectPropertySyntax
-//@[002:00013) |   | ├─IdentifierSyntax
-//@[002:00013) |   | | └─Token(Identifier) |bApiVersion|
-//@[013:00014) |   | ├─Token(Colon) |:|
-//@[015:00035) |   | └─PropertyAccessSyntax
-//@[015:00024) |   |   ├─VariableAccessSyntax
-//@[015:00024) |   |   | └─IdentifierSyntax
-//@[015:00024) |   |   |   └─Token(Identifier) |resourceB|
-//@[024:00025) |   |   ├─Token(Dot) |.|
-//@[025:00035) |   |   └─IdentifierSyntax
-//@[025:00035) |   |     └─Token(Identifier) |apiVersion|
-//@[035:00037) |   ├─Token(NewLine) |\r\n|
   aKind: resourceA.kind
-//@[002:00023) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |aKind|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00023) |   | └─PropertyAccessSyntax
-//@[009:00018) |   |   ├─VariableAccessSyntax
-//@[009:00018) |   |   | └─IdentifierSyntax
-//@[009:00018) |   |   |   └─Token(Identifier) |resourceA|
-//@[018:00019) |   |   ├─Token(Dot) |.|
-//@[019:00023) |   |   └─IdentifierSyntax
-//@[019:00023) |   |     └─Token(Identifier) |kind|
-//@[023:00025) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 var varBRuntime = [
-//@[000:00037) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00015) | ├─IdentifierSyntax
-//@[004:00015) | | └─Token(Identifier) |varBRuntime|
-//@[016:00017) | ├─Token(Assignment) |=|
-//@[018:00037) | └─ArraySyntax
-//@[018:00019) |   ├─Token(LeftSquare) |[|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   varARuntime
-//@[002:00013) |   ├─ArrayItemSyntax
-//@[002:00013) |   | └─VariableAccessSyntax
-//@[002:00013) |   |   └─IdentifierSyntax
-//@[002:00013) |   |     └─Token(Identifier) |varARuntime|
-//@[013:00015) |   ├─Token(NewLine) |\r\n|
 ]
-//@[000:00001) |   └─Token(RightSquare) |]|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 var resourceCRef = {
-//@[000:00043) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00016) | ├─IdentifierSyntax
-//@[004:00016) | | └─Token(Identifier) |resourceCRef|
-//@[017:00018) | ├─Token(Assignment) |=|
-//@[019:00043) | └─ObjectSyntax
-//@[019:00020) |   ├─Token(LeftBrace) |{|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
   id: resourceC.id
-//@[002:00018) |   ├─ObjectPropertySyntax
-//@[002:00004) |   | ├─IdentifierSyntax
-//@[002:00004) |   | | └─Token(Identifier) |id|
-//@[004:00005) |   | ├─Token(Colon) |:|
-//@[006:00018) |   | └─PropertyAccessSyntax
-//@[006:00015) |   |   ├─VariableAccessSyntax
-//@[006:00015) |   |   | └─IdentifierSyntax
-//@[006:00015) |   |   |   └─Token(Identifier) |resourceC|
-//@[015:00016) |   |   ├─Token(Dot) |.|
-//@[016:00018) |   |   └─IdentifierSyntax
-//@[016:00018) |   |     └─Token(Identifier) |id|
-//@[018:00020) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00003) ├─Token(NewLine) |\r\n|
 var setResourceCRef = true
-//@[000:00026) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00019) | ├─IdentifierSyntax
-//@[004:00019) | | └─Token(Identifier) |setResourceCRef|
-//@[020:00021) | ├─Token(Assignment) |=|
-//@[022:00026) | └─BooleanLiteralSyntax
-//@[022:00026) |   └─Token(TrueKeyword) |true|
-//@[026:00030) ├─Token(NewLine) |\r\n\r\n|
 
 resource resourceD 'My.Rp/typeD@2020-01-01' = {
-//@[000:00231) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |resourceD|
-//@[019:00043) | ├─StringSyntax
-//@[019:00043) | | └─Token(StringComplete) |'My.Rp/typeD@2020-01-01'|
-//@[044:00045) | ├─Token(Assignment) |=|
-//@[046:00231) | └─ObjectSyntax
-//@[046:00047) |   ├─Token(LeftBrace) |{|
-//@[047:00049) |   ├─Token(NewLine) |\r\n|
   name: 'constant'
-//@[002:00018) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00018) |   | └─StringSyntax
-//@[008:00018) |   |   └─Token(StringComplete) |'constant'|
-//@[018:00020) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00159) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00159) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     runtime: varBRuntime
-//@[004:00024) |   |   ├─ObjectPropertySyntax
-//@[004:00011) |   |   | ├─IdentifierSyntax
-//@[004:00011) |   |   | | └─Token(Identifier) |runtime|
-//@[011:00012) |   |   | ├─Token(Colon) |:|
-//@[013:00024) |   |   | └─VariableAccessSyntax
-//@[013:00024) |   |   |   └─IdentifierSyntax
-//@[013:00024) |   |   |     └─Token(Identifier) |varBRuntime|
-//@[024:00026) |   |   ├─Token(NewLine) |\r\n|
     // repro for https://github.com/Azure/bicep/issues/316
-//@[058:00060) |   |   ├─Token(NewLine) |\r\n|
     repro316: setResourceCRef ? resourceCRef : null
-//@[004:00051) |   |   ├─ObjectPropertySyntax
-//@[004:00012) |   |   | ├─IdentifierSyntax
-//@[004:00012) |   |   | | └─Token(Identifier) |repro316|
-//@[012:00013) |   |   | ├─Token(Colon) |:|
-//@[014:00051) |   |   | └─TernaryOperationSyntax
-//@[014:00029) |   |   |   ├─VariableAccessSyntax
-//@[014:00029) |   |   |   | └─IdentifierSyntax
-//@[014:00029) |   |   |   |   └─Token(Identifier) |setResourceCRef|
-//@[030:00031) |   |   |   ├─Token(Question) |?|
-//@[032:00044) |   |   |   ├─VariableAccessSyntax
-//@[032:00044) |   |   |   | └─IdentifierSyntax
-//@[032:00044) |   |   |   |   └─Token(Identifier) |resourceCRef|
-//@[045:00046) |   |   |   ├─Token(Colon) |:|
-//@[047:00051) |   |   |   └─NullLiteralSyntax
-//@[047:00051) |   |   |     └─Token(NullKeyword) |null|
-//@[051:00053) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 var myInterpKey = 'abc'
-//@[000:00023) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00015) | ├─IdentifierSyntax
-//@[004:00015) | | └─Token(Identifier) |myInterpKey|
-//@[016:00017) | ├─Token(Assignment) |=|
-//@[018:00023) | └─StringSyntax
-//@[018:00023) |   └─Token(StringComplete) |'abc'|
-//@[023:00025) ├─Token(NewLine) |\r\n|
 resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
-//@[000:00202) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00027) | ├─IdentifierSyntax
-//@[009:00027) | | └─Token(Identifier) |resourceWithInterp|
-//@[028:00053) | ├─StringSyntax
-//@[028:00053) | | └─Token(StringComplete) |'My.Rp/interp@2020-01-01'|
-//@[054:00055) | ├─Token(Assignment) |=|
-//@[056:00202) | └─ObjectSyntax
-//@[056:00057) |   ├─Token(LeftBrace) |{|
-//@[057:00059) |   ├─Token(NewLine) |\r\n|
   name: 'interpTest'
-//@[002:00020) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00020) |   | └─StringSyntax
-//@[008:00020) |   |   └─Token(StringComplete) |'interpTest'|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00118) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00118) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     '${myInterpKey}': 1
-//@[004:00023) |   |   ├─ObjectPropertySyntax
-//@[004:00020) |   |   | ├─StringSyntax
-//@[004:00007) |   |   | | ├─Token(StringLeftPiece) |'${|
-//@[007:00018) |   |   | | ├─VariableAccessSyntax
-//@[007:00018) |   |   | | | └─IdentifierSyntax
-//@[007:00018) |   |   | | |   └─Token(Identifier) |myInterpKey|
-//@[018:00020) |   |   | | └─Token(StringRightPiece) |}'|
-//@[020:00021) |   |   | ├─Token(Colon) |:|
-//@[022:00023) |   |   | └─IntegerLiteralSyntax
-//@[022:00023) |   |   |   └─Token(Integer) |1|
-//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
     'abc${myInterpKey}def': 2
-//@[004:00029) |   |   ├─ObjectPropertySyntax
-//@[004:00026) |   |   | ├─StringSyntax
-//@[004:00010) |   |   | | ├─Token(StringLeftPiece) |'abc${|
-//@[010:00021) |   |   | | ├─VariableAccessSyntax
-//@[010:00021) |   |   | | | └─IdentifierSyntax
-//@[010:00021) |   |   | | |   └─Token(Identifier) |myInterpKey|
-//@[021:00026) |   |   | | └─Token(StringRightPiece) |}def'|
-//@[026:00027) |   |   | ├─Token(Colon) |:|
-//@[028:00029) |   |   | └─IntegerLiteralSyntax
-//@[028:00029) |   |   |   └─Token(Integer) |2|
-//@[029:00031) |   |   ├─Token(NewLine) |\r\n|
     '${myInterpKey}abc${myInterpKey}': 3
-//@[004:00040) |   |   ├─ObjectPropertySyntax
-//@[004:00037) |   |   | ├─StringSyntax
-//@[004:00007) |   |   | | ├─Token(StringLeftPiece) |'${|
-//@[007:00018) |   |   | | ├─VariableAccessSyntax
-//@[007:00018) |   |   | | | └─IdentifierSyntax
-//@[007:00018) |   |   | | |   └─Token(Identifier) |myInterpKey|
-//@[018:00024) |   |   | | ├─Token(StringMiddlePiece) |}abc${|
-//@[024:00035) |   |   | | ├─VariableAccessSyntax
-//@[024:00035) |   |   | | | └─IdentifierSyntax
-//@[024:00035) |   |   | | |   └─Token(Identifier) |myInterpKey|
-//@[035:00037) |   |   | | └─Token(StringRightPiece) |}'|
-//@[037:00038) |   |   | ├─Token(Colon) |:|
-//@[039:00040) |   |   | └─IntegerLiteralSyntax
-//@[039:00040) |   |   |   └─Token(Integer) |3|
-//@[040:00042) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
-//@[000:00234) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00029) | ├─IdentifierSyntax
-//@[009:00029) | | └─Token(Identifier) |resourceWithEscaping|
-//@[030:00061) | ├─StringSyntax
-//@[030:00061) | | └─Token(StringComplete) |'My.Rp/mockResource@2020-01-01'|
-//@[062:00063) | ├─Token(Assignment) |=|
-//@[064:00234) | └─ObjectSyntax
-//@[064:00065) |   ├─Token(LeftBrace) |{|
-//@[065:00067) |   ├─Token(NewLine) |\r\n|
   name: 'test'
-//@[002:00014) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00014) |   | └─StringSyntax
-//@[008:00014) |   |   └─Token(StringComplete) |'test'|
-//@[014:00016) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00148) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00148) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     // both key and value should be escaped in template output
-//@[062:00064) |   |   ├─Token(NewLine) |\r\n|
     '[resourceGroup().location]': '[resourceGroup().location]'
-//@[004:00062) |   |   ├─ObjectPropertySyntax
-//@[004:00032) |   |   | ├─StringSyntax
-//@[004:00032) |   |   | | └─Token(StringComplete) |'[resourceGroup().location]'|
-//@[032:00033) |   |   | ├─Token(Colon) |:|
-//@[034:00062) |   |   | └─StringSyntax
-//@[034:00062) |   |   |   └─Token(StringComplete) |'[resourceGroup().location]'|
-//@[062:00064) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 param shouldDeployVm bool = true
-//@[000:00032) ├─ParameterDeclarationSyntax
-//@[000:00005) | ├─Token(Identifier) |param|
-//@[006:00020) | ├─IdentifierSyntax
-//@[006:00020) | | └─Token(Identifier) |shouldDeployVm|
-//@[021:00025) | ├─TypeVariableAccessSyntax
-//@[021:00025) | | └─IdentifierSyntax
-//@[021:00025) | |   └─Token(Identifier) |bool|
-//@[026:00032) | └─ParameterDefaultValueSyntax
-//@[026:00027) |   ├─Token(Assignment) |=|
-//@[028:00032) |   └─BooleanLiteralSyntax
-//@[028:00032) |     └─Token(TrueKeyword) |true|
-//@[032:00036) ├─Token(NewLine) |\r\n\r\n|
 
 @sys.description('this is vmWithCondition')
-//@[000:00308) ├─ResourceDeclarationSyntax
-//@[000:00043) | ├─DecoratorSyntax
-//@[000:00001) | | ├─Token(At) |@|
-//@[001:00043) | | └─InstanceFunctionCallSyntax
-//@[001:00004) | |   ├─VariableAccessSyntax
-//@[001:00004) | |   | └─IdentifierSyntax
-//@[001:00004) | |   |   └─Token(Identifier) |sys|
-//@[004:00005) | |   ├─Token(Dot) |.|
-//@[005:00016) | |   ├─IdentifierSyntax
-//@[005:00016) | |   | └─Token(Identifier) |description|
-//@[016:00017) | |   ├─Token(LeftParen) |(|
-//@[017:00042) | |   ├─FunctionArgumentSyntax
-//@[017:00042) | |   | └─StringSyntax
-//@[017:00042) | |   |   └─Token(StringComplete) |'this is vmWithCondition'|
-//@[042:00043) | |   └─Token(RightParen) |)|
-//@[043:00045) | ├─Token(NewLine) |\r\n|
 resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (shouldDeployVm) {
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00024) | ├─IdentifierSyntax
-//@[009:00024) | | └─Token(Identifier) |vmWithCondition|
-//@[025:00071) | ├─StringSyntax
-//@[025:00071) | | └─Token(StringComplete) |'Microsoft.Compute/virtualMachines@2020-06-01'|
-//@[072:00073) | ├─Token(Assignment) |=|
-//@[074:00263) | └─IfConditionSyntax
-//@[074:00076) |   ├─Token(Identifier) |if|
-//@[077:00093) |   ├─ParenthesizedExpressionSyntax
-//@[077:00078) |   | ├─Token(LeftParen) |(|
-//@[078:00092) |   | ├─VariableAccessSyntax
-//@[078:00092) |   | | └─IdentifierSyntax
-//@[078:00092) |   | |   └─Token(Identifier) |shouldDeployVm|
-//@[092:00093) |   | └─Token(RightParen) |)|
-//@[094:00263) |   └─ObjectSyntax
-//@[094:00095) |     ├─Token(LeftBrace) |{|
-//@[095:00097) |     ├─Token(NewLine) |\r\n|
   name: 'vmName'
-//@[002:00016) |     ├─ObjectPropertySyntax
-//@[002:00006) |     | ├─IdentifierSyntax
-//@[002:00006) |     | | └─Token(Identifier) |name|
-//@[006:00007) |     | ├─Token(Colon) |:|
-//@[008:00016) |     | └─StringSyntax
-//@[008:00016) |     |   └─Token(StringComplete) |'vmName'|
-//@[016:00018) |     ├─Token(NewLine) |\r\n|
   location: 'westus'
-//@[002:00020) |     ├─ObjectPropertySyntax
-//@[002:00010) |     | ├─IdentifierSyntax
-//@[002:00010) |     | | └─Token(Identifier) |location|
-//@[010:00011) |     | ├─Token(Colon) |:|
-//@[012:00020) |     | └─StringSyntax
-//@[012:00020) |     |   └─Token(StringComplete) |'westus'|
-//@[020:00022) |     ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00123) |     ├─ObjectPropertySyntax
-//@[002:00012) |     | ├─IdentifierSyntax
-//@[002:00012) |     | | └─Token(Identifier) |properties|
-//@[012:00013) |     | ├─Token(Colon) |:|
-//@[014:00123) |     | └─ObjectSyntax
-//@[014:00015) |     |   ├─Token(LeftBrace) |{|
-//@[015:00017) |     |   ├─Token(NewLine) |\r\n|
     osProfile: {
-//@[004:00101) |     |   ├─ObjectPropertySyntax
-//@[004:00013) |     |   | ├─IdentifierSyntax
-//@[004:00013) |     |   | | └─Token(Identifier) |osProfile|
-//@[013:00014) |     |   | ├─Token(Colon) |:|
-//@[015:00101) |     |   | └─ObjectSyntax
-//@[015:00016) |     |   |   ├─Token(LeftBrace) |{|
-//@[016:00018) |     |   |   ├─Token(NewLine) |\r\n|
       windowsConfiguration: {
-//@[006:00076) |     |   |   ├─ObjectPropertySyntax
-//@[006:00026) |     |   |   | ├─IdentifierSyntax
-//@[006:00026) |     |   |   | | └─Token(Identifier) |windowsConfiguration|
-//@[026:00027) |     |   |   | ├─Token(Colon) |:|
-//@[028:00076) |     |   |   | └─ObjectSyntax
-//@[028:00029) |     |   |   |   ├─Token(LeftBrace) |{|
-//@[029:00031) |     |   |   |   ├─Token(NewLine) |\r\n|
         enableAutomaticUpdates: true
-//@[008:00036) |     |   |   |   ├─ObjectPropertySyntax
-//@[008:00030) |     |   |   |   | ├─IdentifierSyntax
-//@[008:00030) |     |   |   |   | | └─Token(Identifier) |enableAutomaticUpdates|
-//@[030:00031) |     |   |   |   | ├─Token(Colon) |:|
-//@[032:00036) |     |   |   |   | └─BooleanLiteralSyntax
-//@[032:00036) |     |   |   |   |   └─Token(TrueKeyword) |true|
-//@[036:00038) |     |   |   |   ├─Token(NewLine) |\r\n|
       }
-//@[006:00007) |     |   |   |   └─Token(RightBrace) |}|
-//@[007:00009) |     |   |   ├─Token(NewLine) |\r\n|
     }
-//@[004:00005) |     |   |   └─Token(RightBrace) |}|
-//@[005:00007) |     |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |     |   └─Token(RightBrace) |}|
-//@[003:00005) |     ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |     └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 @sys.description('this is another vmWithCondition')
-//@[000:00339) ├─ResourceDeclarationSyntax
-//@[000:00051) | ├─DecoratorSyntax
-//@[000:00001) | | ├─Token(At) |@|
-//@[001:00051) | | └─InstanceFunctionCallSyntax
-//@[001:00004) | |   ├─VariableAccessSyntax
-//@[001:00004) | |   | └─IdentifierSyntax
-//@[001:00004) | |   |   └─Token(Identifier) |sys|
-//@[004:00005) | |   ├─Token(Dot) |.|
-//@[005:00016) | |   ├─IdentifierSyntax
-//@[005:00016) | |   | └─Token(Identifier) |description|
-//@[016:00017) | |   ├─Token(LeftParen) |(|
-//@[017:00050) | |   ├─FunctionArgumentSyntax
-//@[017:00050) | |   | └─StringSyntax
-//@[017:00050) | |   |   └─Token(StringComplete) |'this is another vmWithCondition'|
-//@[050:00051) | |   └─Token(RightParen) |)|
-//@[051:00053) | ├─Token(NewLine) |\r\n|
 resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00025) | ├─IdentifierSyntax
-//@[009:00025) | | └─Token(Identifier) |vmWithCondition2|
-//@[026:00072) | ├─StringSyntax
-//@[026:00072) | | └─Token(StringComplete) |'Microsoft.Compute/virtualMachines@2020-06-01'|
-//@[073:00074) | ├─Token(Assignment) |=|
-//@[074:00076) | ├─Token(NewLine) |\r\n|
                     if (shouldDeployVm) {
-//@[020:00210) | └─IfConditionSyntax
-//@[020:00022) |   ├─Token(Identifier) |if|
-//@[023:00039) |   ├─ParenthesizedExpressionSyntax
-//@[023:00024) |   | ├─Token(LeftParen) |(|
-//@[024:00038) |   | ├─VariableAccessSyntax
-//@[024:00038) |   | | └─IdentifierSyntax
-//@[024:00038) |   | |   └─Token(Identifier) |shouldDeployVm|
-//@[038:00039) |   | └─Token(RightParen) |)|
-//@[040:00210) |   └─ObjectSyntax
-//@[040:00041) |     ├─Token(LeftBrace) |{|
-//@[041:00043) |     ├─Token(NewLine) |\r\n|
   name: 'vmName2'
-//@[002:00017) |     ├─ObjectPropertySyntax
-//@[002:00006) |     | ├─IdentifierSyntax
-//@[002:00006) |     | | └─Token(Identifier) |name|
-//@[006:00007) |     | ├─Token(Colon) |:|
-//@[008:00017) |     | └─StringSyntax
-//@[008:00017) |     |   └─Token(StringComplete) |'vmName2'|
-//@[017:00019) |     ├─Token(NewLine) |\r\n|
   location: 'westus'
-//@[002:00020) |     ├─ObjectPropertySyntax
-//@[002:00010) |     | ├─IdentifierSyntax
-//@[002:00010) |     | | └─Token(Identifier) |location|
-//@[010:00011) |     | ├─Token(Colon) |:|
-//@[012:00020) |     | └─StringSyntax
-//@[012:00020) |     |   └─Token(StringComplete) |'westus'|
-//@[020:00022) |     ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00123) |     ├─ObjectPropertySyntax
-//@[002:00012) |     | ├─IdentifierSyntax
-//@[002:00012) |     | | └─Token(Identifier) |properties|
-//@[012:00013) |     | ├─Token(Colon) |:|
-//@[014:00123) |     | └─ObjectSyntax
-//@[014:00015) |     |   ├─Token(LeftBrace) |{|
-//@[015:00017) |     |   ├─Token(NewLine) |\r\n|
     osProfile: {
-//@[004:00101) |     |   ├─ObjectPropertySyntax
-//@[004:00013) |     |   | ├─IdentifierSyntax
-//@[004:00013) |     |   | | └─Token(Identifier) |osProfile|
-//@[013:00014) |     |   | ├─Token(Colon) |:|
-//@[015:00101) |     |   | └─ObjectSyntax
-//@[015:00016) |     |   |   ├─Token(LeftBrace) |{|
-//@[016:00018) |     |   |   ├─Token(NewLine) |\r\n|
       windowsConfiguration: {
-//@[006:00076) |     |   |   ├─ObjectPropertySyntax
-//@[006:00026) |     |   |   | ├─IdentifierSyntax
-//@[006:00026) |     |   |   | | └─Token(Identifier) |windowsConfiguration|
-//@[026:00027) |     |   |   | ├─Token(Colon) |:|
-//@[028:00076) |     |   |   | └─ObjectSyntax
-//@[028:00029) |     |   |   |   ├─Token(LeftBrace) |{|
-//@[029:00031) |     |   |   |   ├─Token(NewLine) |\r\n|
         enableAutomaticUpdates: true
-//@[008:00036) |     |   |   |   ├─ObjectPropertySyntax
-//@[008:00030) |     |   |   |   | ├─IdentifierSyntax
-//@[008:00030) |     |   |   |   | | └─Token(Identifier) |enableAutomaticUpdates|
-//@[030:00031) |     |   |   |   | ├─Token(Colon) |:|
-//@[032:00036) |     |   |   |   | └─BooleanLiteralSyntax
-//@[032:00036) |     |   |   |   |   └─Token(TrueKeyword) |true|
-//@[036:00038) |     |   |   |   ├─Token(NewLine) |\r\n|
       }
-//@[006:00007) |     |   |   |   └─Token(RightBrace) |}|
-//@[007:00009) |     |   |   ├─Token(NewLine) |\r\n|
     }
-//@[004:00005) |     |   |   └─Token(RightBrace) |}|
-//@[005:00007) |     |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |     |   └─Token(RightBrace) |}|
-//@[003:00005) |     ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |     └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource extension1 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:00110) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00019) | ├─IdentifierSyntax
-//@[009:00019) | | └─Token(Identifier) |extension1|
-//@[020:00056) | ├─StringSyntax
-//@[020:00056) | | └─Token(StringComplete) |'My.Rp/extensionResource@2020-12-01'|
-//@[057:00058) | ├─Token(Assignment) |=|
-//@[059:00110) | └─ObjectSyntax
-//@[059:00060) |   ├─Token(LeftBrace) |{|
-//@[060:00062) |   ├─Token(NewLine) |\r\n|
   name: 'extension'
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00019) |   | └─StringSyntax
-//@[008:00019) |   |   └─Token(StringComplete) |'extension'|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   scope: vmWithCondition
-//@[002:00024) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |scope|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00024) |   | └─VariableAccessSyntax
-//@[009:00024) |   |   └─IdentifierSyntax
-//@[009:00024) |   |     └─Token(Identifier) |vmWithCondition|
-//@[024:00026) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource extension2 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:00105) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00019) | ├─IdentifierSyntax
-//@[009:00019) | | └─Token(Identifier) |extension2|
-//@[020:00056) | ├─StringSyntax
-//@[020:00056) | | └─Token(StringComplete) |'My.Rp/extensionResource@2020-12-01'|
-//@[057:00058) | ├─Token(Assignment) |=|
-//@[059:00105) | └─ObjectSyntax
-//@[059:00060) |   ├─Token(LeftBrace) |{|
-//@[060:00062) |   ├─Token(NewLine) |\r\n|
   name: 'extension'
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00019) |   | └─StringSyntax
-//@[008:00019) |   |   └─Token(StringComplete) |'extension'|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   scope: extension1
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |scope|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00019) |   | └─VariableAccessSyntax
-//@[009:00019) |   |   └─IdentifierSyntax
-//@[009:00019) |   |     └─Token(Identifier) |extension1|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
-//@[000:00359) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00030) | ├─IdentifierSyntax
-//@[009:00030) | | └─Token(Identifier) |extensionDependencies|
-//@[031:00062) | ├─StringSyntax
-//@[031:00062) | | └─Token(StringComplete) |'My.Rp/mockResource@2020-01-01'|
-//@[063:00064) | ├─Token(Assignment) |=|
-//@[065:00359) | └─ObjectSyntax
-//@[065:00066) |   ├─Token(LeftBrace) |{|
-//@[066:00068) |   ├─Token(NewLine) |\r\n|
   name: 'extensionDependencies'
-//@[002:00031) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00031) |   | └─StringSyntax
-//@[008:00031) |   |   └─Token(StringComplete) |'extensionDependencies'|
-//@[031:00033) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00255) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00255) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     res1: vmWithCondition.id
-//@[004:00028) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |res1|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00028) |   |   | └─PropertyAccessSyntax
-//@[010:00025) |   |   |   ├─VariableAccessSyntax
-//@[010:00025) |   |   |   | └─IdentifierSyntax
-//@[010:00025) |   |   |   |   └─Token(Identifier) |vmWithCondition|
-//@[025:00026) |   |   |   ├─Token(Dot) |.|
-//@[026:00028) |   |   |   └─IdentifierSyntax
-//@[026:00028) |   |   |     └─Token(Identifier) |id|
-//@[028:00030) |   |   ├─Token(NewLine) |\r\n|
     res1runtime: vmWithCondition.properties.something
-//@[004:00053) |   |   ├─ObjectPropertySyntax
-//@[004:00015) |   |   | ├─IdentifierSyntax
-//@[004:00015) |   |   | | └─Token(Identifier) |res1runtime|
-//@[015:00016) |   |   | ├─Token(Colon) |:|
-//@[017:00053) |   |   | └─PropertyAccessSyntax
-//@[017:00043) |   |   |   ├─PropertyAccessSyntax
-//@[017:00032) |   |   |   | ├─VariableAccessSyntax
-//@[017:00032) |   |   |   | | └─IdentifierSyntax
-//@[017:00032) |   |   |   | |   └─Token(Identifier) |vmWithCondition|
-//@[032:00033) |   |   |   | ├─Token(Dot) |.|
-//@[033:00043) |   |   |   | └─IdentifierSyntax
-//@[033:00043) |   |   |   |   └─Token(Identifier) |properties|
-//@[043:00044) |   |   |   ├─Token(Dot) |.|
-//@[044:00053) |   |   |   └─IdentifierSyntax
-//@[044:00053) |   |   |     └─Token(Identifier) |something|
-//@[053:00055) |   |   ├─Token(NewLine) |\r\n|
     res2: extension1.id
-//@[004:00023) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |res2|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00023) |   |   | └─PropertyAccessSyntax
-//@[010:00020) |   |   |   ├─VariableAccessSyntax
-//@[010:00020) |   |   |   | └─IdentifierSyntax
-//@[010:00020) |   |   |   |   └─Token(Identifier) |extension1|
-//@[020:00021) |   |   |   ├─Token(Dot) |.|
-//@[021:00023) |   |   |   └─IdentifierSyntax
-//@[021:00023) |   |   |     └─Token(Identifier) |id|
-//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
     res2runtime: extension1.properties.something
-//@[004:00048) |   |   ├─ObjectPropertySyntax
-//@[004:00015) |   |   | ├─IdentifierSyntax
-//@[004:00015) |   |   | | └─Token(Identifier) |res2runtime|
-//@[015:00016) |   |   | ├─Token(Colon) |:|
-//@[017:00048) |   |   | └─PropertyAccessSyntax
-//@[017:00038) |   |   |   ├─PropertyAccessSyntax
-//@[017:00027) |   |   |   | ├─VariableAccessSyntax
-//@[017:00027) |   |   |   | | └─IdentifierSyntax
-//@[017:00027) |   |   |   | |   └─Token(Identifier) |extension1|
-//@[027:00028) |   |   |   | ├─Token(Dot) |.|
-//@[028:00038) |   |   |   | └─IdentifierSyntax
-//@[028:00038) |   |   |   |   └─Token(Identifier) |properties|
-//@[038:00039) |   |   |   ├─Token(Dot) |.|
-//@[039:00048) |   |   |   └─IdentifierSyntax
-//@[039:00048) |   |   |     └─Token(Identifier) |something|
-//@[048:00050) |   |   ├─Token(NewLine) |\r\n|
     res3: extension2.id
-//@[004:00023) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |res3|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00023) |   |   | └─PropertyAccessSyntax
-//@[010:00020) |   |   |   ├─VariableAccessSyntax
-//@[010:00020) |   |   |   | └─IdentifierSyntax
-//@[010:00020) |   |   |   |   └─Token(Identifier) |extension2|
-//@[020:00021) |   |   |   ├─Token(Dot) |.|
-//@[021:00023) |   |   |   └─IdentifierSyntax
-//@[021:00023) |   |   |     └─Token(Identifier) |id|
-//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
     res3runtime: extension2.properties.something
-//@[004:00048) |   |   ├─ObjectPropertySyntax
-//@[004:00015) |   |   | ├─IdentifierSyntax
-//@[004:00015) |   |   | | └─Token(Identifier) |res3runtime|
-//@[015:00016) |   |   | ├─Token(Colon) |:|
-//@[017:00048) |   |   | └─PropertyAccessSyntax
-//@[017:00038) |   |   |   ├─PropertyAccessSyntax
-//@[017:00027) |   |   |   | ├─VariableAccessSyntax
-//@[017:00027) |   |   |   | | └─IdentifierSyntax
-//@[017:00027) |   |   |   | |   └─Token(Identifier) |extension2|
-//@[027:00028) |   |   |   | ├─Token(Dot) |.|
-//@[028:00038) |   |   |   | └─IdentifierSyntax
-//@[028:00038) |   |   |   |   └─Token(Identifier) |properties|
-//@[038:00039) |   |   |   ├─Token(Dot) |.|
-//@[039:00048) |   |   |   └─IdentifierSyntax
-//@[039:00048) |   |   |     └─Token(Identifier) |something|
-//@[048:00050) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 @sys.description('this is existing1')
-//@[000:00162) ├─ResourceDeclarationSyntax
-//@[000:00037) | ├─DecoratorSyntax
-//@[000:00001) | | ├─Token(At) |@|
-//@[001:00037) | | └─InstanceFunctionCallSyntax
-//@[001:00004) | |   ├─VariableAccessSyntax
-//@[001:00004) | |   | └─IdentifierSyntax
-//@[001:00004) | |   |   └─Token(Identifier) |sys|
-//@[004:00005) | |   ├─Token(Dot) |.|
-//@[005:00016) | |   ├─IdentifierSyntax
-//@[005:00016) | |   | └─Token(Identifier) |description|
-//@[016:00017) | |   ├─Token(LeftParen) |(|
-//@[017:00036) | |   ├─FunctionArgumentSyntax
-//@[017:00036) | |   | └─StringSyntax
-//@[017:00036) | |   |   └─Token(StringComplete) |'this is existing1'|
-//@[036:00037) | |   └─Token(RightParen) |)|
-//@[037:00039) | ├─Token(NewLine) |\r\n|
 resource existing1 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |existing1|
-//@[019:00065) | ├─StringSyntax
-//@[019:00065) | | └─Token(StringComplete) |'Mock.Rp/existingExtensionResource@2020-01-01'|
-//@[066:00074) | ├─Token(Identifier) |existing|
-//@[075:00076) | ├─Token(Assignment) |=|
-//@[077:00123) | └─ObjectSyntax
-//@[077:00078) |   ├─Token(LeftBrace) |{|
-//@[078:00080) |   ├─Token(NewLine) |\r\n|
   name: 'existing1'
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00019) |   | └─StringSyntax
-//@[008:00019) |   |   └─Token(StringComplete) |'existing1'|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   scope: extension1
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |scope|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00019) |   | └─VariableAccessSyntax
-//@[009:00019) |   |   └─IdentifierSyntax
-//@[009:00019) |   |     └─Token(Identifier) |extension1|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource existing2 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[000:00122) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |existing2|
-//@[019:00065) | ├─StringSyntax
-//@[019:00065) | | └─Token(StringComplete) |'Mock.Rp/existingExtensionResource@2020-01-01'|
-//@[066:00074) | ├─Token(Identifier) |existing|
-//@[075:00076) | ├─Token(Assignment) |=|
-//@[077:00122) | └─ObjectSyntax
-//@[077:00078) |   ├─Token(LeftBrace) |{|
-//@[078:00080) |   ├─Token(NewLine) |\r\n|
   name: 'existing2'
-//@[002:00019) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00019) |   | └─StringSyntax
-//@[008:00019) |   |   └─Token(StringComplete) |'existing2'|
-//@[019:00021) |   ├─Token(NewLine) |\r\n|
   scope: existing1
-//@[002:00018) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |scope|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00018) |   | └─VariableAccessSyntax
-//@[009:00018) |   |   └─IdentifierSyntax
-//@[009:00018) |   |     └─Token(Identifier) |existing1|
-//@[018:00020) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource extension3 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:00105) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00019) | ├─IdentifierSyntax
-//@[009:00019) | | └─Token(Identifier) |extension3|
-//@[020:00056) | ├─StringSyntax
-//@[020:00056) | | └─Token(StringComplete) |'My.Rp/extensionResource@2020-12-01'|
-//@[057:00058) | ├─Token(Assignment) |=|
-//@[059:00105) | └─ObjectSyntax
-//@[059:00060) |   ├─Token(LeftBrace) |{|
-//@[060:00062) |   ├─Token(NewLine) |\r\n|
   name: 'extension3'
-//@[002:00020) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00020) |   | └─StringSyntax
-//@[008:00020) |   |   └─Token(StringComplete) |'extension3'|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
   scope: existing1
-//@[002:00018) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |scope|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00018) |   | └─VariableAccessSyntax
-//@[009:00018) |   |   └─IdentifierSyntax
-//@[009:00018) |   |     └─Token(Identifier) |existing1|
-//@[018:00020) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 /*
   valid loop cases
-*/ 
-//@[003:00005) ├─Token(NewLine) |\r\n|
+*/
 var storageAccounts = [
-//@[000:00129) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00019) | ├─IdentifierSyntax
-//@[004:00019) | | └─Token(Identifier) |storageAccounts|
-//@[020:00021) | ├─Token(Assignment) |=|
-//@[022:00129) | └─ArraySyntax
-//@[022:00023) |   ├─Token(LeftSquare) |[|
-//@[023:00025) |   ├─Token(NewLine) |\r\n|
   {
-//@[002:00050) |   ├─ArrayItemSyntax
-//@[002:00050) |   | └─ObjectSyntax
-//@[002:00003) |   |   ├─Token(LeftBrace) |{|
-//@[003:00005) |   |   ├─Token(NewLine) |\r\n|
     name: 'one'
-//@[004:00015) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00015) |   |   | └─StringSyntax
-//@[010:00015) |   |   |   └─Token(StringComplete) |'one'|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     location: 'eastus2'
-//@[004:00023) |   |   ├─ObjectPropertySyntax
-//@[004:00012) |   |   | ├─IdentifierSyntax
-//@[004:00012) |   |   | | └─Token(Identifier) |location|
-//@[012:00013) |   |   | ├─Token(Colon) |:|
-//@[014:00023) |   |   | └─StringSyntax
-//@[014:00023) |   |   |   └─Token(StringComplete) |'eastus2'|
-//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
   {
-//@[002:00049) |   ├─ArrayItemSyntax
-//@[002:00049) |   | └─ObjectSyntax
-//@[002:00003) |   |   ├─Token(LeftBrace) |{|
-//@[003:00005) |   |   ├─Token(NewLine) |\r\n|
     name: 'two'
-//@[004:00015) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00015) |   |   | └─StringSyntax
-//@[010:00015) |   |   |   └─Token(StringComplete) |'two'|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     location: 'westus'
-//@[004:00022) |   |   ├─ObjectPropertySyntax
-//@[004:00012) |   |   | ├─IdentifierSyntax
-//@[004:00012) |   |   | | └─Token(Identifier) |location|
-//@[012:00013) |   |   | ├─Token(Colon) |:|
-//@[014:00022) |   |   | └─StringSyntax
-//@[014:00022) |   |   |   └─Token(StringComplete) |'westus'|
-//@[022:00024) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 ]
-//@[000:00001) |   └─Token(RightSquare) |]|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 // just a storage account loop
-//@[030:00032) ├─Token(NewLine) |\r\n|
 @sys.description('this is just a storage account loop')
-//@[000:00284) ├─ResourceDeclarationSyntax
-//@[000:00055) | ├─DecoratorSyntax
-//@[000:00001) | | ├─Token(At) |@|
-//@[001:00055) | | └─InstanceFunctionCallSyntax
-//@[001:00004) | |   ├─VariableAccessSyntax
-//@[001:00004) | |   | └─IdentifierSyntax
-//@[001:00004) | |   |   └─Token(Identifier) |sys|
-//@[004:00005) | |   ├─Token(Dot) |.|
-//@[005:00016) | |   ├─IdentifierSyntax
-//@[005:00016) | |   | └─Token(Identifier) |description|
-//@[016:00017) | |   ├─Token(LeftParen) |(|
-//@[017:00054) | |   ├─FunctionArgumentSyntax
-//@[017:00054) | |   | └─StringSyntax
-//@[017:00054) | |   |   └─Token(StringComplete) |'this is just a storage account loop'|
-//@[054:00055) | |   └─Token(RightParen) |)|
-//@[055:00057) | ├─Token(NewLine) |\r\n|
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00025) | ├─IdentifierSyntax
-//@[009:00025) | | └─Token(Identifier) |storageResources|
-//@[026:00072) | ├─StringSyntax
-//@[026:00072) | | └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2019-06-01'|
-//@[073:00074) | ├─Token(Assignment) |=|
-//@[075:00227) | └─ForSyntax
-//@[075:00076) |   ├─Token(LeftSquare) |[|
-//@[076:00079) |   ├─Token(Identifier) |for|
-//@[080:00087) |   ├─LocalVariableSyntax
-//@[080:00087) |   | └─IdentifierSyntax
-//@[080:00087) |   |   └─Token(Identifier) |account|
-//@[088:00090) |   ├─Token(Identifier) |in|
-//@[091:00106) |   ├─VariableAccessSyntax
-//@[091:00106) |   | └─IdentifierSyntax
-//@[091:00106) |   |   └─Token(Identifier) |storageAccounts|
-//@[106:00107) |   ├─Token(Colon) |:|
-//@[108:00226) |   ├─ObjectSyntax
-//@[108:00109) |   | ├─Token(LeftBrace) |{|
-//@[109:00111) |   | ├─Token(NewLine) |\r\n|
   name: account.name
-//@[002:00020) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00020) |   | | └─PropertyAccessSyntax
-//@[008:00015) |   | |   ├─VariableAccessSyntax
-//@[008:00015) |   | |   | └─IdentifierSyntax
-//@[008:00015) |   | |   |   └─Token(Identifier) |account|
-//@[015:00016) |   | |   ├─Token(Dot) |.|
-//@[016:00020) |   | |   └─IdentifierSyntax
-//@[016:00020) |   | |     └─Token(Identifier) |name|
-//@[020:00022) |   | ├─Token(NewLine) |\r\n|
   location: account.location
-//@[002:00028) |   | ├─ObjectPropertySyntax
-//@[002:00010) |   | | ├─IdentifierSyntax
-//@[002:00010) |   | | | └─Token(Identifier) |location|
-//@[010:00011) |   | | ├─Token(Colon) |:|
-//@[012:00028) |   | | └─PropertyAccessSyntax
-//@[012:00019) |   | |   ├─VariableAccessSyntax
-//@[012:00019) |   | |   | └─IdentifierSyntax
-//@[012:00019) |   | |   |   └─Token(Identifier) |account|
-//@[019:00020) |   | |   ├─Token(Dot) |.|
-//@[020:00028) |   | |   └─IdentifierSyntax
-//@[020:00028) |   | |     └─Token(Identifier) |location|
-//@[028:00030) |   | ├─Token(NewLine) |\r\n|
   sku: {
-//@[002:00039) |   | ├─ObjectPropertySyntax
-//@[002:00005) |   | | ├─IdentifierSyntax
-//@[002:00005) |   | | | └─Token(Identifier) |sku|
-//@[005:00006) |   | | ├─Token(Colon) |:|
-//@[007:00039) |   | | └─ObjectSyntax
-//@[007:00008) |   | |   ├─Token(LeftBrace) |{|
-//@[008:00010) |   | |   ├─Token(NewLine) |\r\n|
     name: 'Standard_LRS'
-//@[004:00024) |   | |   ├─ObjectPropertySyntax
-//@[004:00008) |   | |   | ├─IdentifierSyntax
-//@[004:00008) |   | |   | | └─Token(Identifier) |name|
-//@[008:00009) |   | |   | ├─Token(Colon) |:|
-//@[010:00024) |   | |   | └─StringSyntax
-//@[010:00024) |   | |   |   └─Token(StringComplete) |'Standard_LRS'|
-//@[024:00026) |   | |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   | |   └─Token(RightBrace) |}|
-//@[003:00005) |   | ├─Token(NewLine) |\r\n|
   kind: 'StorageV2'
-//@[002:00019) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |kind|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00019) |   | | └─StringSyntax
-//@[008:00019) |   | |   └─Token(StringComplete) |'StorageV2'|
-//@[019:00021) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 // storage account loop with index
-//@[034:00036) ├─Token(NewLine) |\r\n|
 @sys.description('this is just a storage account loop with index')
-//@[000:00318) ├─ResourceDeclarationSyntax
-//@[000:00066) | ├─DecoratorSyntax
-//@[000:00001) | | ├─Token(At) |@|
-//@[001:00066) | | └─InstanceFunctionCallSyntax
-//@[001:00004) | |   ├─VariableAccessSyntax
-//@[001:00004) | |   | └─IdentifierSyntax
-//@[001:00004) | |   |   └─Token(Identifier) |sys|
-//@[004:00005) | |   ├─Token(Dot) |.|
-//@[005:00016) | |   ├─IdentifierSyntax
-//@[005:00016) | |   | └─Token(Identifier) |description|
-//@[016:00017) | |   ├─Token(LeftParen) |(|
-//@[017:00065) | |   ├─FunctionArgumentSyntax
-//@[017:00065) | |   | └─StringSyntax
-//@[017:00065) | |   |   └─Token(StringComplete) |'this is just a storage account loop with index'|
-//@[065:00066) | |   └─Token(RightParen) |)|
-//@[066:00068) | ├─Token(NewLine) |\r\n|
 resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, i) in storageAccounts: {
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00034) | ├─IdentifierSyntax
-//@[009:00034) | | └─Token(Identifier) |storageResourcesWithIndex|
-//@[035:00081) | ├─StringSyntax
-//@[035:00081) | | └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2019-06-01'|
-//@[082:00083) | ├─Token(Assignment) |=|
-//@[084:00250) | └─ForSyntax
-//@[084:00085) |   ├─Token(LeftSquare) |[|
-//@[085:00088) |   ├─Token(Identifier) |for|
-//@[089:00101) |   ├─VariableBlockSyntax
-//@[089:00090) |   | ├─Token(LeftParen) |(|
-//@[090:00097) |   | ├─LocalVariableSyntax
-//@[090:00097) |   | | └─IdentifierSyntax
-//@[090:00097) |   | |   └─Token(Identifier) |account|
-//@[097:00098) |   | ├─Token(Comma) |,|
-//@[099:00100) |   | ├─LocalVariableSyntax
-//@[099:00100) |   | | └─IdentifierSyntax
-//@[099:00100) |   | |   └─Token(Identifier) |i|
-//@[100:00101) |   | └─Token(RightParen) |)|
-//@[102:00104) |   ├─Token(Identifier) |in|
-//@[105:00120) |   ├─VariableAccessSyntax
-//@[105:00120) |   | └─IdentifierSyntax
-//@[105:00120) |   |   └─Token(Identifier) |storageAccounts|
-//@[120:00121) |   ├─Token(Colon) |:|
-//@[122:00249) |   ├─ObjectSyntax
-//@[122:00123) |   | ├─Token(LeftBrace) |{|
-//@[123:00125) |   | ├─Token(NewLine) |\r\n|
   name: '${account.name}${i}'
-//@[002:00029) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00029) |   | | └─StringSyntax
-//@[008:00011) |   | |   ├─Token(StringLeftPiece) |'${|
-//@[011:00023) |   | |   ├─PropertyAccessSyntax
-//@[011:00018) |   | |   | ├─VariableAccessSyntax
-//@[011:00018) |   | |   | | └─IdentifierSyntax
-//@[011:00018) |   | |   | |   └─Token(Identifier) |account|
-//@[018:00019) |   | |   | ├─Token(Dot) |.|
-//@[019:00023) |   | |   | └─IdentifierSyntax
-//@[019:00023) |   | |   |   └─Token(Identifier) |name|
-//@[023:00026) |   | |   ├─Token(StringMiddlePiece) |}${|
-//@[026:00027) |   | |   ├─VariableAccessSyntax
-//@[026:00027) |   | |   | └─IdentifierSyntax
-//@[026:00027) |   | |   |   └─Token(Identifier) |i|
-//@[027:00029) |   | |   └─Token(StringRightPiece) |}'|
-//@[029:00031) |   | ├─Token(NewLine) |\r\n|
   location: account.location
-//@[002:00028) |   | ├─ObjectPropertySyntax
-//@[002:00010) |   | | ├─IdentifierSyntax
-//@[002:00010) |   | | | └─Token(Identifier) |location|
-//@[010:00011) |   | | ├─Token(Colon) |:|
-//@[012:00028) |   | | └─PropertyAccessSyntax
-//@[012:00019) |   | |   ├─VariableAccessSyntax
-//@[012:00019) |   | |   | └─IdentifierSyntax
-//@[012:00019) |   | |   |   └─Token(Identifier) |account|
-//@[019:00020) |   | |   ├─Token(Dot) |.|
-//@[020:00028) |   | |   └─IdentifierSyntax
-//@[020:00028) |   | |     └─Token(Identifier) |location|
-//@[028:00030) |   | ├─Token(NewLine) |\r\n|
   sku: {
-//@[002:00039) |   | ├─ObjectPropertySyntax
-//@[002:00005) |   | | ├─IdentifierSyntax
-//@[002:00005) |   | | | └─Token(Identifier) |sku|
-//@[005:00006) |   | | ├─Token(Colon) |:|
-//@[007:00039) |   | | └─ObjectSyntax
-//@[007:00008) |   | |   ├─Token(LeftBrace) |{|
-//@[008:00010) |   | |   ├─Token(NewLine) |\r\n|
     name: 'Standard_LRS'
-//@[004:00024) |   | |   ├─ObjectPropertySyntax
-//@[004:00008) |   | |   | ├─IdentifierSyntax
-//@[004:00008) |   | |   | | └─Token(Identifier) |name|
-//@[008:00009) |   | |   | ├─Token(Colon) |:|
-//@[010:00024) |   | |   | └─StringSyntax
-//@[010:00024) |   | |   |   └─Token(StringComplete) |'Standard_LRS'|
-//@[024:00026) |   | |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   | |   └─Token(RightBrace) |}|
-//@[003:00005) |   | ├─Token(NewLine) |\r\n|
   kind: 'StorageV2'
-//@[002:00019) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |kind|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00019) |   | | └─StringSyntax
-//@[008:00019) |   | |   └─Token(StringComplete) |'StorageV2'|
-//@[019:00021) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 // basic nested loop
-//@[020:00022) ├─Token(NewLine) |\r\n|
 @sys.description('this is just a basic nested loop')
-//@[000:00399) ├─ResourceDeclarationSyntax
-//@[000:00052) | ├─DecoratorSyntax
-//@[000:00001) | | ├─Token(At) |@|
-//@[001:00052) | | └─InstanceFunctionCallSyntax
-//@[001:00004) | |   ├─VariableAccessSyntax
-//@[001:00004) | |   | └─IdentifierSyntax
-//@[001:00004) | |   |   └─Token(Identifier) |sys|
-//@[004:00005) | |   ├─Token(Dot) |.|
-//@[005:00016) | |   ├─IdentifierSyntax
-//@[005:00016) | |   | └─Token(Identifier) |description|
-//@[016:00017) | |   ├─Token(LeftParen) |(|
-//@[017:00051) | |   ├─FunctionArgumentSyntax
-//@[017:00051) | |   | └─StringSyntax
-//@[017:00051) | |   |   └─Token(StringComplete) |'this is just a basic nested loop'|
-//@[051:00052) | |   └─Token(RightParen) |)|
-//@[052:00054) | ├─Token(NewLine) |\r\n|
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00013) | ├─IdentifierSyntax
-//@[009:00013) | | └─Token(Identifier) |vnet|
-//@[014:00060) | ├─StringSyntax
-//@[014:00060) | | └─Token(StringComplete) |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[061:00062) | ├─Token(Assignment) |=|
-//@[063:00345) | └─ForSyntax
-//@[063:00064) |   ├─Token(LeftSquare) |[|
-//@[064:00067) |   ├─Token(Identifier) |for|
-//@[068:00069) |   ├─LocalVariableSyntax
-//@[068:00069) |   | └─IdentifierSyntax
-//@[068:00069) |   |   └─Token(Identifier) |i|
-//@[070:00072) |   ├─Token(Identifier) |in|
-//@[073:00084) |   ├─FunctionCallSyntax
-//@[073:00078) |   | ├─IdentifierSyntax
-//@[073:00078) |   | | └─Token(Identifier) |range|
-//@[078:00079) |   | ├─Token(LeftParen) |(|
-//@[079:00080) |   | ├─FunctionArgumentSyntax
-//@[079:00080) |   | | └─IntegerLiteralSyntax
-//@[079:00080) |   | |   └─Token(Integer) |0|
-//@[080:00081) |   | ├─Token(Comma) |,|
-//@[082:00083) |   | ├─FunctionArgumentSyntax
-//@[082:00083) |   | | └─IntegerLiteralSyntax
-//@[082:00083) |   | |   └─Token(Integer) |3|
-//@[083:00084) |   | └─Token(RightParen) |)|
-//@[084:00085) |   ├─Token(Colon) |:|
-//@[086:00344) |   ├─ObjectSyntax
-//@[086:00087) |   | ├─Token(LeftBrace) |{|
-//@[087:00089) |   | ├─Token(NewLine) |\r\n|
   name: 'vnet-${i}'
-//@[002:00019) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00019) |   | | └─StringSyntax
-//@[008:00016) |   | |   ├─Token(StringLeftPiece) |'vnet-${|
-//@[016:00017) |   | |   ├─VariableAccessSyntax
-//@[016:00017) |   | |   | └─IdentifierSyntax
-//@[016:00017) |   | |   |   └─Token(Identifier) |i|
-//@[017:00019) |   | |   └─Token(StringRightPiece) |}'|
-//@[019:00021) |   | ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00231) |   | ├─ObjectPropertySyntax
-//@[002:00012) |   | | ├─IdentifierSyntax
-//@[002:00012) |   | | | └─Token(Identifier) |properties|
-//@[012:00013) |   | | ├─Token(Colon) |:|
-//@[014:00231) |   | | └─ObjectSyntax
-//@[014:00015) |   | |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   | |   ├─Token(NewLine) |\r\n|
     subnets: [for j in range(0, 4): {
-//@[004:00209) |   | |   ├─ObjectPropertySyntax
-//@[004:00011) |   | |   | ├─IdentifierSyntax
-//@[004:00011) |   | |   | | └─Token(Identifier) |subnets|
-//@[011:00012) |   | |   | ├─Token(Colon) |:|
-//@[013:00209) |   | |   | └─ForSyntax
-//@[013:00014) |   | |   |   ├─Token(LeftSquare) |[|
-//@[014:00017) |   | |   |   ├─Token(Identifier) |for|
-//@[018:00019) |   | |   |   ├─LocalVariableSyntax
-//@[018:00019) |   | |   |   | └─IdentifierSyntax
-//@[018:00019) |   | |   |   |   └─Token(Identifier) |j|
-//@[020:00022) |   | |   |   ├─Token(Identifier) |in|
-//@[023:00034) |   | |   |   ├─FunctionCallSyntax
-//@[023:00028) |   | |   |   | ├─IdentifierSyntax
-//@[023:00028) |   | |   |   | | └─Token(Identifier) |range|
-//@[028:00029) |   | |   |   | ├─Token(LeftParen) |(|
-//@[029:00030) |   | |   |   | ├─FunctionArgumentSyntax
-//@[029:00030) |   | |   |   | | └─IntegerLiteralSyntax
-//@[029:00030) |   | |   |   | |   └─Token(Integer) |0|
-//@[030:00031) |   | |   |   | ├─Token(Comma) |,|
-//@[032:00033) |   | |   |   | ├─FunctionArgumentSyntax
-//@[032:00033) |   | |   |   | | └─IntegerLiteralSyntax
-//@[032:00033) |   | |   |   | |   └─Token(Integer) |4|
-//@[033:00034) |   | |   |   | └─Token(RightParen) |)|
-//@[034:00035) |   | |   |   ├─Token(Colon) |:|
-//@[036:00208) |   | |   |   ├─ObjectSyntax
-//@[036:00037) |   | |   |   | ├─Token(LeftBrace) |{|
-//@[037:00039) |   | |   |   | ├─Token(NewLine) |\r\n|
       // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
-//@[062:00064) |   | |   |   | ├─Token(NewLine) |\r\n|
-     
-//@[005:00007) |   | |   |   | ├─Token(NewLine) |\r\n|
+
       // #completionTest(6) -> subnetIdAndPropertiesNoColon
-//@[059:00061) |   | |   |   | ├─Token(NewLine) |\r\n|
       name: 'subnet-${i}-${j}'
-//@[006:00030) |   | |   |   | ├─ObjectPropertySyntax
-//@[006:00010) |   | |   |   | | ├─IdentifierSyntax
-//@[006:00010) |   | |   |   | | | └─Token(Identifier) |name|
-//@[010:00011) |   | |   |   | | ├─Token(Colon) |:|
-//@[012:00030) |   | |   |   | | └─StringSyntax
-//@[012:00022) |   | |   |   | |   ├─Token(StringLeftPiece) |'subnet-${|
-//@[022:00023) |   | |   |   | |   ├─VariableAccessSyntax
-//@[022:00023) |   | |   |   | |   | └─IdentifierSyntax
-//@[022:00023) |   | |   |   | |   |   └─Token(Identifier) |i|
-//@[023:00027) |   | |   |   | |   ├─Token(StringMiddlePiece) |}-${|
-//@[027:00028) |   | |   |   | |   ├─VariableAccessSyntax
-//@[027:00028) |   | |   |   | |   | └─IdentifierSyntax
-//@[027:00028) |   | |   |   | |   |   └─Token(Identifier) |j|
-//@[028:00030) |   | |   |   | |   └─Token(StringRightPiece) |}'|
-//@[030:00032) |   | |   |   | ├─Token(NewLine) |\r\n|
     }]
-//@[004:00005) |   | |   |   | └─Token(RightBrace) |}|
-//@[005:00006) |   | |   |   └─Token(RightSquare) |]|
-//@[006:00008) |   | |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   | |   └─Token(RightBrace) |}|
-//@[003:00005) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 // duplicate identifiers within the loop are allowed
-//@[052:00054) ├─Token(NewLine) |\r\n|
 resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[000:00239) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00039) | ├─IdentifierSyntax
-//@[009:00039) | | └─Token(Identifier) |duplicateIdentifiersWithinLoop|
-//@[040:00086) | ├─StringSyntax
-//@[040:00086) | | └─Token(StringComplete) |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[087:00088) | ├─Token(Assignment) |=|
-//@[089:00239) | └─ForSyntax
-//@[089:00090) |   ├─Token(LeftSquare) |[|
-//@[090:00093) |   ├─Token(Identifier) |for|
-//@[094:00095) |   ├─LocalVariableSyntax
-//@[094:00095) |   | └─IdentifierSyntax
-//@[094:00095) |   |   └─Token(Identifier) |i|
-//@[096:00098) |   ├─Token(Identifier) |in|
-//@[099:00110) |   ├─FunctionCallSyntax
-//@[099:00104) |   | ├─IdentifierSyntax
-//@[099:00104) |   | | └─Token(Identifier) |range|
-//@[104:00105) |   | ├─Token(LeftParen) |(|
-//@[105:00106) |   | ├─FunctionArgumentSyntax
-//@[105:00106) |   | | └─IntegerLiteralSyntax
-//@[105:00106) |   | |   └─Token(Integer) |0|
-//@[106:00107) |   | ├─Token(Comma) |,|
-//@[108:00109) |   | ├─FunctionArgumentSyntax
-//@[108:00109) |   | | └─IntegerLiteralSyntax
-//@[108:00109) |   | |   └─Token(Integer) |3|
-//@[109:00110) |   | └─Token(RightParen) |)|
-//@[110:00111) |   ├─Token(Colon) |:|
-//@[112:00238) |   ├─ObjectSyntax
-//@[112:00113) |   | ├─Token(LeftBrace) |{|
-//@[113:00115) |   | ├─Token(NewLine) |\r\n|
   name: 'vnet-${i}'
-//@[002:00019) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00019) |   | | └─StringSyntax
-//@[008:00016) |   | |   ├─Token(StringLeftPiece) |'vnet-${|
-//@[016:00017) |   | |   ├─VariableAccessSyntax
-//@[016:00017) |   | |   | └─IdentifierSyntax
-//@[016:00017) |   | |   |   └─Token(Identifier) |i|
-//@[017:00019) |   | |   └─Token(StringRightPiece) |}'|
-//@[019:00021) |   | ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00099) |   | ├─ObjectPropertySyntax
-//@[002:00012) |   | | ├─IdentifierSyntax
-//@[002:00012) |   | | | └─Token(Identifier) |properties|
-//@[012:00013) |   | | ├─Token(Colon) |:|
-//@[014:00099) |   | | └─ObjectSyntax
-//@[014:00015) |   | |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   | |   ├─Token(NewLine) |\r\n|
     subnets: [for i in range(0, 4): {
-//@[004:00077) |   | |   ├─ObjectPropertySyntax
-//@[004:00011) |   | |   | ├─IdentifierSyntax
-//@[004:00011) |   | |   | | └─Token(Identifier) |subnets|
-//@[011:00012) |   | |   | ├─Token(Colon) |:|
-//@[013:00077) |   | |   | └─ForSyntax
-//@[013:00014) |   | |   |   ├─Token(LeftSquare) |[|
-//@[014:00017) |   | |   |   ├─Token(Identifier) |for|
-//@[018:00019) |   | |   |   ├─LocalVariableSyntax
-//@[018:00019) |   | |   |   | └─IdentifierSyntax
-//@[018:00019) |   | |   |   |   └─Token(Identifier) |i|
-//@[020:00022) |   | |   |   ├─Token(Identifier) |in|
-//@[023:00034) |   | |   |   ├─FunctionCallSyntax
-//@[023:00028) |   | |   |   | ├─IdentifierSyntax
-//@[023:00028) |   | |   |   | | └─Token(Identifier) |range|
-//@[028:00029) |   | |   |   | ├─Token(LeftParen) |(|
-//@[029:00030) |   | |   |   | ├─FunctionArgumentSyntax
-//@[029:00030) |   | |   |   | | └─IntegerLiteralSyntax
-//@[029:00030) |   | |   |   | |   └─Token(Integer) |0|
-//@[030:00031) |   | |   |   | ├─Token(Comma) |,|
-//@[032:00033) |   | |   |   | ├─FunctionArgumentSyntax
-//@[032:00033) |   | |   |   | | └─IntegerLiteralSyntax
-//@[032:00033) |   | |   |   | |   └─Token(Integer) |4|
-//@[033:00034) |   | |   |   | └─Token(RightParen) |)|
-//@[034:00035) |   | |   |   ├─Token(Colon) |:|
-//@[036:00076) |   | |   |   ├─ObjectSyntax
-//@[036:00037) |   | |   |   | ├─Token(LeftBrace) |{|
-//@[037:00039) |   | |   |   | ├─Token(NewLine) |\r\n|
       name: 'subnet-${i}-${i}'
-//@[006:00030) |   | |   |   | ├─ObjectPropertySyntax
-//@[006:00010) |   | |   |   | | ├─IdentifierSyntax
-//@[006:00010) |   | |   |   | | | └─Token(Identifier) |name|
-//@[010:00011) |   | |   |   | | ├─Token(Colon) |:|
-//@[012:00030) |   | |   |   | | └─StringSyntax
-//@[012:00022) |   | |   |   | |   ├─Token(StringLeftPiece) |'subnet-${|
-//@[022:00023) |   | |   |   | |   ├─VariableAccessSyntax
-//@[022:00023) |   | |   |   | |   | └─IdentifierSyntax
-//@[022:00023) |   | |   |   | |   |   └─Token(Identifier) |i|
-//@[023:00027) |   | |   |   | |   ├─Token(StringMiddlePiece) |}-${|
-//@[027:00028) |   | |   |   | |   ├─VariableAccessSyntax
-//@[027:00028) |   | |   |   | |   | └─IdentifierSyntax
-//@[027:00028) |   | |   |   | |   |   └─Token(Identifier) |i|
-//@[028:00030) |   | |   |   | |   └─Token(StringRightPiece) |}'|
-//@[030:00032) |   | |   |   | ├─Token(NewLine) |\r\n|
     }]
-//@[004:00005) |   | |   |   | └─Token(RightBrace) |}|
-//@[005:00006) |   | |   |   └─Token(RightSquare) |]|
-//@[006:00008) |   | |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   | |   └─Token(RightBrace) |}|
-//@[003:00005) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 // duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
-//@[100:00102) ├─Token(NewLine) |\r\n|
 var canHaveDuplicatesAcrossScopes = 'hello'
-//@[000:00043) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00033) | ├─IdentifierSyntax
-//@[004:00033) | | └─Token(Identifier) |canHaveDuplicatesAcrossScopes|
-//@[034:00035) | ├─Token(Assignment) |=|
-//@[036:00043) | └─StringSyntax
-//@[036:00043) |   └─Token(StringComplete) |'hello'|
-//@[043:00045) ├─Token(NewLine) |\r\n|
 resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
-//@[000:00292) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00036) | ├─IdentifierSyntax
-//@[009:00036) | | └─Token(Identifier) |duplicateInGlobalAndOneLoop|
-//@[037:00083) | ├─StringSyntax
-//@[037:00083) | | └─Token(StringComplete) |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[084:00085) | ├─Token(Assignment) |=|
-//@[086:00292) | └─ForSyntax
-//@[086:00087) |   ├─Token(LeftSquare) |[|
-//@[087:00090) |   ├─Token(Identifier) |for|
-//@[091:00120) |   ├─LocalVariableSyntax
-//@[091:00120) |   | └─IdentifierSyntax
-//@[091:00120) |   |   └─Token(Identifier) |canHaveDuplicatesAcrossScopes|
-//@[121:00123) |   ├─Token(Identifier) |in|
-//@[124:00135) |   ├─FunctionCallSyntax
-//@[124:00129) |   | ├─IdentifierSyntax
-//@[124:00129) |   | | └─Token(Identifier) |range|
-//@[129:00130) |   | ├─Token(LeftParen) |(|
-//@[130:00131) |   | ├─FunctionArgumentSyntax
-//@[130:00131) |   | | └─IntegerLiteralSyntax
-//@[130:00131) |   | |   └─Token(Integer) |0|
-//@[131:00132) |   | ├─Token(Comma) |,|
-//@[133:00134) |   | ├─FunctionArgumentSyntax
-//@[133:00134) |   | | └─IntegerLiteralSyntax
-//@[133:00134) |   | |   └─Token(Integer) |3|
-//@[134:00135) |   | └─Token(RightParen) |)|
-//@[135:00136) |   ├─Token(Colon) |:|
-//@[137:00291) |   ├─ObjectSyntax
-//@[137:00138) |   | ├─Token(LeftBrace) |{|
-//@[138:00140) |   | ├─Token(NewLine) |\r\n|
   name: 'vnet-${canHaveDuplicatesAcrossScopes}'
-//@[002:00047) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00047) |   | | └─StringSyntax
-//@[008:00016) |   | |   ├─Token(StringLeftPiece) |'vnet-${|
-//@[016:00045) |   | |   ├─VariableAccessSyntax
-//@[016:00045) |   | |   | └─IdentifierSyntax
-//@[016:00045) |   | |   |   └─Token(Identifier) |canHaveDuplicatesAcrossScopes|
-//@[045:00047) |   | |   └─Token(StringRightPiece) |}'|
-//@[047:00049) |   | ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00099) |   | ├─ObjectPropertySyntax
-//@[002:00012) |   | | ├─IdentifierSyntax
-//@[002:00012) |   | | | └─Token(Identifier) |properties|
-//@[012:00013) |   | | ├─Token(Colon) |:|
-//@[014:00099) |   | | └─ObjectSyntax
-//@[014:00015) |   | |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   | |   ├─Token(NewLine) |\r\n|
     subnets: [for i in range(0, 4): {
-//@[004:00077) |   | |   ├─ObjectPropertySyntax
-//@[004:00011) |   | |   | ├─IdentifierSyntax
-//@[004:00011) |   | |   | | └─Token(Identifier) |subnets|
-//@[011:00012) |   | |   | ├─Token(Colon) |:|
-//@[013:00077) |   | |   | └─ForSyntax
-//@[013:00014) |   | |   |   ├─Token(LeftSquare) |[|
-//@[014:00017) |   | |   |   ├─Token(Identifier) |for|
-//@[018:00019) |   | |   |   ├─LocalVariableSyntax
-//@[018:00019) |   | |   |   | └─IdentifierSyntax
-//@[018:00019) |   | |   |   |   └─Token(Identifier) |i|
-//@[020:00022) |   | |   |   ├─Token(Identifier) |in|
-//@[023:00034) |   | |   |   ├─FunctionCallSyntax
-//@[023:00028) |   | |   |   | ├─IdentifierSyntax
-//@[023:00028) |   | |   |   | | └─Token(Identifier) |range|
-//@[028:00029) |   | |   |   | ├─Token(LeftParen) |(|
-//@[029:00030) |   | |   |   | ├─FunctionArgumentSyntax
-//@[029:00030) |   | |   |   | | └─IntegerLiteralSyntax
-//@[029:00030) |   | |   |   | |   └─Token(Integer) |0|
-//@[030:00031) |   | |   |   | ├─Token(Comma) |,|
-//@[032:00033) |   | |   |   | ├─FunctionArgumentSyntax
-//@[032:00033) |   | |   |   | | └─IntegerLiteralSyntax
-//@[032:00033) |   | |   |   | |   └─Token(Integer) |4|
-//@[033:00034) |   | |   |   | └─Token(RightParen) |)|
-//@[034:00035) |   | |   |   ├─Token(Colon) |:|
-//@[036:00076) |   | |   |   ├─ObjectSyntax
-//@[036:00037) |   | |   |   | ├─Token(LeftBrace) |{|
-//@[037:00039) |   | |   |   | ├─Token(NewLine) |\r\n|
       name: 'subnet-${i}-${i}'
-//@[006:00030) |   | |   |   | ├─ObjectPropertySyntax
-//@[006:00010) |   | |   |   | | ├─IdentifierSyntax
-//@[006:00010) |   | |   |   | | | └─Token(Identifier) |name|
-//@[010:00011) |   | |   |   | | ├─Token(Colon) |:|
-//@[012:00030) |   | |   |   | | └─StringSyntax
-//@[012:00022) |   | |   |   | |   ├─Token(StringLeftPiece) |'subnet-${|
-//@[022:00023) |   | |   |   | |   ├─VariableAccessSyntax
-//@[022:00023) |   | |   |   | |   | └─IdentifierSyntax
-//@[022:00023) |   | |   |   | |   |   └─Token(Identifier) |i|
-//@[023:00027) |   | |   |   | |   ├─Token(StringMiddlePiece) |}-${|
-//@[027:00028) |   | |   |   | |   ├─VariableAccessSyntax
-//@[027:00028) |   | |   |   | |   | └─IdentifierSyntax
-//@[027:00028) |   | |   |   | |   |   └─Token(Identifier) |i|
-//@[028:00030) |   | |   |   | |   └─Token(StringRightPiece) |}'|
-//@[030:00032) |   | |   |   | ├─Token(NewLine) |\r\n|
     }]
-//@[004:00005) |   | |   |   | └─Token(RightBrace) |}|
-//@[005:00006) |   | |   |   └─Token(RightSquare) |]|
-//@[006:00008) |   | |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   | |   └─Token(RightBrace) |}|
-//@[003:00005) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 // duplicate in global and multiple loop scopes are allowed (inner hides the outer)
-//@[083:00085) ├─Token(NewLine) |\r\n|
 var duplicatesEverywhere = 'hello'
-//@[000:00034) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00024) | ├─IdentifierSyntax
-//@[004:00024) | | └─Token(Identifier) |duplicatesEverywhere|
-//@[025:00026) | ├─Token(Assignment) |=|
-//@[027:00034) | └─StringSyntax
-//@[027:00034) |   └─Token(StringComplete) |'hello'|
-//@[034:00036) ├─Token(NewLine) |\r\n|
 resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
-//@[000:00308) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00037) | ├─IdentifierSyntax
-//@[009:00037) | | └─Token(Identifier) |duplicateInGlobalAndTwoLoops|
-//@[038:00084) | ├─StringSyntax
-//@[038:00084) | | └─Token(StringComplete) |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[085:00086) | ├─Token(Assignment) |=|
-//@[087:00308) | └─ForSyntax
-//@[087:00088) |   ├─Token(LeftSquare) |[|
-//@[088:00091) |   ├─Token(Identifier) |for|
-//@[092:00112) |   ├─LocalVariableSyntax
-//@[092:00112) |   | └─IdentifierSyntax
-//@[092:00112) |   |   └─Token(Identifier) |duplicatesEverywhere|
-//@[113:00115) |   ├─Token(Identifier) |in|
-//@[116:00127) |   ├─FunctionCallSyntax
-//@[116:00121) |   | ├─IdentifierSyntax
-//@[116:00121) |   | | └─Token(Identifier) |range|
-//@[121:00122) |   | ├─Token(LeftParen) |(|
-//@[122:00123) |   | ├─FunctionArgumentSyntax
-//@[122:00123) |   | | └─IntegerLiteralSyntax
-//@[122:00123) |   | |   └─Token(Integer) |0|
-//@[123:00124) |   | ├─Token(Comma) |,|
-//@[125:00126) |   | ├─FunctionArgumentSyntax
-//@[125:00126) |   | | └─IntegerLiteralSyntax
-//@[125:00126) |   | |   └─Token(Integer) |3|
-//@[126:00127) |   | └─Token(RightParen) |)|
-//@[127:00128) |   ├─Token(Colon) |:|
-//@[129:00307) |   ├─ObjectSyntax
-//@[129:00130) |   | ├─Token(LeftBrace) |{|
-//@[130:00132) |   | ├─Token(NewLine) |\r\n|
   name: 'vnet-${duplicatesEverywhere}'
-//@[002:00038) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00038) |   | | └─StringSyntax
-//@[008:00016) |   | |   ├─Token(StringLeftPiece) |'vnet-${|
-//@[016:00036) |   | |   ├─VariableAccessSyntax
-//@[016:00036) |   | |   | └─IdentifierSyntax
-//@[016:00036) |   | |   |   └─Token(Identifier) |duplicatesEverywhere|
-//@[036:00038) |   | |   └─Token(StringRightPiece) |}'|
-//@[038:00040) |   | ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00132) |   | ├─ObjectPropertySyntax
-//@[002:00012) |   | | ├─IdentifierSyntax
-//@[002:00012) |   | | | └─Token(Identifier) |properties|
-//@[012:00013) |   | | ├─Token(Colon) |:|
-//@[014:00132) |   | | └─ObjectSyntax
-//@[014:00015) |   | |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   | |   ├─Token(NewLine) |\r\n|
     subnets: [for duplicatesEverywhere in range(0, 4): {
-//@[004:00110) |   | |   ├─ObjectPropertySyntax
-//@[004:00011) |   | |   | ├─IdentifierSyntax
-//@[004:00011) |   | |   | | └─Token(Identifier) |subnets|
-//@[011:00012) |   | |   | ├─Token(Colon) |:|
-//@[013:00110) |   | |   | └─ForSyntax
-//@[013:00014) |   | |   |   ├─Token(LeftSquare) |[|
-//@[014:00017) |   | |   |   ├─Token(Identifier) |for|
-//@[018:00038) |   | |   |   ├─LocalVariableSyntax
-//@[018:00038) |   | |   |   | └─IdentifierSyntax
-//@[018:00038) |   | |   |   |   └─Token(Identifier) |duplicatesEverywhere|
-//@[039:00041) |   | |   |   ├─Token(Identifier) |in|
-//@[042:00053) |   | |   |   ├─FunctionCallSyntax
-//@[042:00047) |   | |   |   | ├─IdentifierSyntax
-//@[042:00047) |   | |   |   | | └─Token(Identifier) |range|
-//@[047:00048) |   | |   |   | ├─Token(LeftParen) |(|
-//@[048:00049) |   | |   |   | ├─FunctionArgumentSyntax
-//@[048:00049) |   | |   |   | | └─IntegerLiteralSyntax
-//@[048:00049) |   | |   |   | |   └─Token(Integer) |0|
-//@[049:00050) |   | |   |   | ├─Token(Comma) |,|
-//@[051:00052) |   | |   |   | ├─FunctionArgumentSyntax
-//@[051:00052) |   | |   |   | | └─IntegerLiteralSyntax
-//@[051:00052) |   | |   |   | |   └─Token(Integer) |4|
-//@[052:00053) |   | |   |   | └─Token(RightParen) |)|
-//@[053:00054) |   | |   |   ├─Token(Colon) |:|
-//@[055:00109) |   | |   |   ├─ObjectSyntax
-//@[055:00056) |   | |   |   | ├─Token(LeftBrace) |{|
-//@[056:00058) |   | |   |   | ├─Token(NewLine) |\r\n|
       name: 'subnet-${duplicatesEverywhere}'
-//@[006:00044) |   | |   |   | ├─ObjectPropertySyntax
-//@[006:00010) |   | |   |   | | ├─IdentifierSyntax
-//@[006:00010) |   | |   |   | | | └─Token(Identifier) |name|
-//@[010:00011) |   | |   |   | | ├─Token(Colon) |:|
-//@[012:00044) |   | |   |   | | └─StringSyntax
-//@[012:00022) |   | |   |   | |   ├─Token(StringLeftPiece) |'subnet-${|
-//@[022:00042) |   | |   |   | |   ├─VariableAccessSyntax
-//@[022:00042) |   | |   |   | |   | └─IdentifierSyntax
-//@[022:00042) |   | |   |   | |   |   └─Token(Identifier) |duplicatesEverywhere|
-//@[042:00044) |   | |   |   | |   └─Token(StringRightPiece) |}'|
-//@[044:00046) |   | |   |   | ├─Token(NewLine) |\r\n|
     }]
-//@[004:00005) |   | |   |   | └─Token(RightBrace) |}|
-//@[005:00006) |   | |   |   └─Token(RightSquare) |]|
-//@[006:00008) |   | |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   | |   └─Token(RightBrace) |}|
-//@[003:00005) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 /*
   Scope values created via array access on a resource collection
 */
-//@[002:00004) ├─Token(NewLine) |\r\n|
 resource dnsZones 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in range(0,4): {
-//@[000:00135) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00017) | ├─IdentifierSyntax
-//@[009:00017) | | └─Token(Identifier) |dnsZones|
-//@[018:00057) | ├─StringSyntax
-//@[018:00057) | | └─Token(StringComplete) |'Microsoft.Network/dnsZones@2018-05-01'|
-//@[058:00059) | ├─Token(Assignment) |=|
-//@[060:00135) | └─ForSyntax
-//@[060:00061) |   ├─Token(LeftSquare) |[|
-//@[061:00064) |   ├─Token(Identifier) |for|
-//@[065:00069) |   ├─LocalVariableSyntax
-//@[065:00069) |   | └─IdentifierSyntax
-//@[065:00069) |   |   └─Token(Identifier) |zone|
-//@[070:00072) |   ├─Token(Identifier) |in|
-//@[073:00083) |   ├─FunctionCallSyntax
-//@[073:00078) |   | ├─IdentifierSyntax
-//@[073:00078) |   | | └─Token(Identifier) |range|
-//@[078:00079) |   | ├─Token(LeftParen) |(|
-//@[079:00080) |   | ├─FunctionArgumentSyntax
-//@[079:00080) |   | | └─IntegerLiteralSyntax
-//@[079:00080) |   | |   └─Token(Integer) |0|
-//@[080:00081) |   | ├─Token(Comma) |,|
-//@[081:00082) |   | ├─FunctionArgumentSyntax
-//@[081:00082) |   | | └─IntegerLiteralSyntax
-//@[081:00082) |   | |   └─Token(Integer) |4|
-//@[082:00083) |   | └─Token(RightParen) |)|
-//@[083:00084) |   ├─Token(Colon) |:|
-//@[085:00134) |   ├─ObjectSyntax
-//@[085:00086) |   | ├─Token(LeftBrace) |{|
-//@[086:00088) |   | ├─Token(NewLine) |\r\n|
   name: 'zone${zone}'
-//@[002:00021) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00021) |   | | └─StringSyntax
-//@[008:00015) |   | |   ├─Token(StringLeftPiece) |'zone${|
-//@[015:00019) |   | |   ├─VariableAccessSyntax
-//@[015:00019) |   | |   | └─IdentifierSyntax
-//@[015:00019) |   | |   |   └─Token(Identifier) |zone|
-//@[019:00021) |   | |   └─Token(StringRightPiece) |}'|
-//@[021:00023) |   | ├─Token(NewLine) |\r\n|
   location: 'global'
-//@[002:00020) |   | ├─ObjectPropertySyntax
-//@[002:00010) |   | | ├─IdentifierSyntax
-//@[002:00010) |   | | | └─Token(Identifier) |location|
-//@[010:00011) |   | | ├─Token(Colon) |:|
-//@[012:00020) |   | | └─StringSyntax
-//@[012:00020) |   | |   └─Token(StringComplete) |'global'|
-//@[020:00022) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 resource locksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for lock in range(0,2): {
-//@[000:00194) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00021) | ├─IdentifierSyntax
-//@[009:00021) | | └─Token(Identifier) |locksOnZones|
-//@[022:00064) | ├─StringSyntax
-//@[022:00064) | | └─Token(StringComplete) |'Microsoft.Authorization/locks@2016-09-01'|
-//@[065:00066) | ├─Token(Assignment) |=|
-//@[067:00194) | └─ForSyntax
-//@[067:00068) |   ├─Token(LeftSquare) |[|
-//@[068:00071) |   ├─Token(Identifier) |for|
-//@[072:00076) |   ├─LocalVariableSyntax
-//@[072:00076) |   | └─IdentifierSyntax
-//@[072:00076) |   |   └─Token(Identifier) |lock|
-//@[077:00079) |   ├─Token(Identifier) |in|
-//@[080:00090) |   ├─FunctionCallSyntax
-//@[080:00085) |   | ├─IdentifierSyntax
-//@[080:00085) |   | | └─Token(Identifier) |range|
-//@[085:00086) |   | ├─Token(LeftParen) |(|
-//@[086:00087) |   | ├─FunctionArgumentSyntax
-//@[086:00087) |   | | └─IntegerLiteralSyntax
-//@[086:00087) |   | |   └─Token(Integer) |0|
-//@[087:00088) |   | ├─Token(Comma) |,|
-//@[088:00089) |   | ├─FunctionArgumentSyntax
-//@[088:00089) |   | | └─IntegerLiteralSyntax
-//@[088:00089) |   | |   └─Token(Integer) |2|
-//@[089:00090) |   | └─Token(RightParen) |)|
-//@[090:00091) |   ├─Token(Colon) |:|
-//@[092:00193) |   ├─ObjectSyntax
-//@[092:00093) |   | ├─Token(LeftBrace) |{|
-//@[093:00095) |   | ├─Token(NewLine) |\r\n|
   name: 'lock${lock}'
-//@[002:00021) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00021) |   | | └─StringSyntax
-//@[008:00015) |   | |   ├─Token(StringLeftPiece) |'lock${|
-//@[015:00019) |   | |   ├─VariableAccessSyntax
-//@[015:00019) |   | |   | └─IdentifierSyntax
-//@[015:00019) |   | |   |   └─Token(Identifier) |lock|
-//@[019:00021) |   | |   └─Token(StringRightPiece) |}'|
-//@[021:00023) |   | ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00047) |   | ├─ObjectPropertySyntax
-//@[002:00012) |   | | ├─IdentifierSyntax
-//@[002:00012) |   | | | └─Token(Identifier) |properties|
-//@[012:00013) |   | | ├─Token(Colon) |:|
-//@[014:00047) |   | | └─ObjectSyntax
-//@[014:00015) |   | |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   | |   ├─Token(NewLine) |\r\n|
     level: 'CanNotDelete'
-//@[004:00025) |   | |   ├─ObjectPropertySyntax
-//@[004:00009) |   | |   | ├─IdentifierSyntax
-//@[004:00009) |   | |   | | └─Token(Identifier) |level|
-//@[009:00010) |   | |   | ├─Token(Colon) |:|
-//@[011:00025) |   | |   | └─StringSyntax
-//@[011:00025) |   | |   |   └─Token(StringComplete) |'CanNotDelete'|
-//@[025:00027) |   | |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   | |   └─Token(RightBrace) |}|
-//@[003:00005) |   | ├─Token(NewLine) |\r\n|
   scope: dnsZones[lock]
-//@[002:00023) |   | ├─ObjectPropertySyntax
-//@[002:00007) |   | | ├─IdentifierSyntax
-//@[002:00007) |   | | | └─Token(Identifier) |scope|
-//@[007:00008) |   | | ├─Token(Colon) |:|
-//@[009:00023) |   | | └─ArrayAccessSyntax
-//@[009:00017) |   | |   ├─VariableAccessSyntax
-//@[009:00017) |   | |   | └─IdentifierSyntax
-//@[009:00017) |   | |   |   └─Token(Identifier) |dnsZones|
-//@[017:00018) |   | |   ├─Token(LeftSquare) |[|
-//@[018:00022) |   | |   ├─VariableAccessSyntax
-//@[018:00022) |   | |   | └─IdentifierSyntax
-//@[018:00022) |   | |   |   └─Token(Identifier) |lock|
-//@[022:00023) |   | |   └─Token(RightSquare) |]|
-//@[023:00025) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 resource moreLocksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for (lock, i) in range(0,3): {
-//@[000:00196) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00025) | ├─IdentifierSyntax
-//@[009:00025) | | └─Token(Identifier) |moreLocksOnZones|
-//@[026:00068) | ├─StringSyntax
-//@[026:00068) | | └─Token(StringComplete) |'Microsoft.Authorization/locks@2016-09-01'|
-//@[069:00070) | ├─Token(Assignment) |=|
-//@[071:00196) | └─ForSyntax
-//@[071:00072) |   ├─Token(LeftSquare) |[|
-//@[072:00075) |   ├─Token(Identifier) |for|
-//@[076:00085) |   ├─VariableBlockSyntax
-//@[076:00077) |   | ├─Token(LeftParen) |(|
-//@[077:00081) |   | ├─LocalVariableSyntax
-//@[077:00081) |   | | └─IdentifierSyntax
-//@[077:00081) |   | |   └─Token(Identifier) |lock|
-//@[081:00082) |   | ├─Token(Comma) |,|
-//@[083:00084) |   | ├─LocalVariableSyntax
-//@[083:00084) |   | | └─IdentifierSyntax
-//@[083:00084) |   | |   └─Token(Identifier) |i|
-//@[084:00085) |   | └─Token(RightParen) |)|
-//@[086:00088) |   ├─Token(Identifier) |in|
-//@[089:00099) |   ├─FunctionCallSyntax
-//@[089:00094) |   | ├─IdentifierSyntax
-//@[089:00094) |   | | └─Token(Identifier) |range|
-//@[094:00095) |   | ├─Token(LeftParen) |(|
-//@[095:00096) |   | ├─FunctionArgumentSyntax
-//@[095:00096) |   | | └─IntegerLiteralSyntax
-//@[095:00096) |   | |   └─Token(Integer) |0|
-//@[096:00097) |   | ├─Token(Comma) |,|
-//@[097:00098) |   | ├─FunctionArgumentSyntax
-//@[097:00098) |   | | └─IntegerLiteralSyntax
-//@[097:00098) |   | |   └─Token(Integer) |3|
-//@[098:00099) |   | └─Token(RightParen) |)|
-//@[099:00100) |   ├─Token(Colon) |:|
-//@[101:00195) |   ├─ObjectSyntax
-//@[101:00102) |   | ├─Token(LeftBrace) |{|
-//@[102:00104) |   | ├─Token(NewLine) |\r\n|
   name: 'another${i}'
-//@[002:00021) |   | ├─ObjectPropertySyntax
-//@[002:00006) |   | | ├─IdentifierSyntax
-//@[002:00006) |   | | | └─Token(Identifier) |name|
-//@[006:00007) |   | | ├─Token(Colon) |:|
-//@[008:00021) |   | | └─StringSyntax
-//@[008:00018) |   | |   ├─Token(StringLeftPiece) |'another${|
-//@[018:00019) |   | |   ├─VariableAccessSyntax
-//@[018:00019) |   | |   | └─IdentifierSyntax
-//@[018:00019) |   | |   |   └─Token(Identifier) |i|
-//@[019:00021) |   | |   └─Token(StringRightPiece) |}'|
-//@[021:00023) |   | ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00043) |   | ├─ObjectPropertySyntax
-//@[002:00012) |   | | ├─IdentifierSyntax
-//@[002:00012) |   | | | └─Token(Identifier) |properties|
-//@[012:00013) |   | | ├─Token(Colon) |:|
-//@[014:00043) |   | | └─ObjectSyntax
-//@[014:00015) |   | |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   | |   ├─Token(NewLine) |\r\n|
     level: 'ReadOnly'
-//@[004:00021) |   | |   ├─ObjectPropertySyntax
-//@[004:00009) |   | |   | ├─IdentifierSyntax
-//@[004:00009) |   | |   | | └─Token(Identifier) |level|
-//@[009:00010) |   | |   | ├─Token(Colon) |:|
-//@[011:00021) |   | |   | └─StringSyntax
-//@[011:00021) |   | |   |   └─Token(StringComplete) |'ReadOnly'|
-//@[021:00023) |   | |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   | |   └─Token(RightBrace) |}|
-//@[003:00005) |   | ├─Token(NewLine) |\r\n|
   scope: dnsZones[i]
-//@[002:00020) |   | ├─ObjectPropertySyntax
-//@[002:00007) |   | | ├─IdentifierSyntax
-//@[002:00007) |   | | | └─Token(Identifier) |scope|
-//@[007:00008) |   | | ├─Token(Colon) |:|
-//@[009:00020) |   | | └─ArrayAccessSyntax
-//@[009:00017) |   | |   ├─VariableAccessSyntax
-//@[009:00017) |   | |   | └─IdentifierSyntax
-//@[009:00017) |   | |   |   └─Token(Identifier) |dnsZones|
-//@[017:00018) |   | |   ├─Token(LeftSquare) |[|
-//@[018:00019) |   | |   ├─VariableAccessSyntax
-//@[018:00019) |   | |   | └─IdentifierSyntax
-//@[018:00019) |   | |   |   └─Token(Identifier) |i|
-//@[019:00020) |   | |   └─Token(RightSquare) |]|
-//@[020:00022) |   | ├─Token(NewLine) |\r\n|
 }]
-//@[000:00001) |   | └─Token(RightBrace) |}|
-//@[001:00002) |   └─Token(RightSquare) |]|
-//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
 
 resource singleLockOnFirstZone 'Microsoft.Authorization/locks@2016-09-01' = {
-//@[000:00170) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00030) | ├─IdentifierSyntax
-//@[009:00030) | | └─Token(Identifier) |singleLockOnFirstZone|
-//@[031:00073) | ├─StringSyntax
-//@[031:00073) | | └─Token(StringComplete) |'Microsoft.Authorization/locks@2016-09-01'|
-//@[074:00075) | ├─Token(Assignment) |=|
-//@[076:00170) | └─ObjectSyntax
-//@[076:00077) |   ├─Token(LeftBrace) |{|
-//@[077:00079) |   ├─Token(NewLine) |\r\n|
   name: 'single-lock'
-//@[002:00021) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00021) |   | └─StringSyntax
-//@[008:00021) |   |   └─Token(StringComplete) |'single-lock'|
-//@[021:00023) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00043) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00043) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     level: 'ReadOnly'
-//@[004:00021) |   |   ├─ObjectPropertySyntax
-//@[004:00009) |   |   | ├─IdentifierSyntax
-//@[004:00009) |   |   | | └─Token(Identifier) |level|
-//@[009:00010) |   |   | ├─Token(Colon) |:|
-//@[011:00021) |   |   | └─StringSyntax
-//@[011:00021) |   |   |   └─Token(StringComplete) |'ReadOnly'|
-//@[021:00023) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
   scope: dnsZones[0]
-//@[002:00020) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |scope|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00020) |   | └─ArrayAccessSyntax
-//@[009:00017) |   |   ├─VariableAccessSyntax
-//@[009:00017) |   |   | └─IdentifierSyntax
-//@[009:00017) |   |   |   └─Token(Identifier) |dnsZones|
-//@[017:00018) |   |   ├─Token(LeftSquare) |[|
-//@[018:00019) |   |   ├─IntegerLiteralSyntax
-//@[018:00019) |   |   | └─Token(Integer) |0|
-//@[019:00020) |   |   └─Token(RightSquare) |]|
-//@[020:00022) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00007) ├─Token(NewLine) |\r\n\r\n\r\n|
 
 
 resource p1_vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@[000:00234) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00016) | ├─IdentifierSyntax
-//@[009:00016) | | └─Token(Identifier) |p1_vnet|
-//@[017:00063) | ├─StringSyntax
-//@[017:00063) | | └─Token(StringComplete) |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[064:00065) | ├─Token(Assignment) |=|
-//@[066:00234) | └─ObjectSyntax
-//@[066:00067) |   ├─Token(LeftBrace) |{|
-//@[067:00069) |   ├─Token(NewLine) |\r\n|
   location: resourceGroup().location
-//@[002:00036) |   ├─ObjectPropertySyntax
-//@[002:00010) |   | ├─IdentifierSyntax
-//@[002:00010) |   | | └─Token(Identifier) |location|
-//@[010:00011) |   | ├─Token(Colon) |:|
-//@[012:00036) |   | └─PropertyAccessSyntax
-//@[012:00027) |   |   ├─FunctionCallSyntax
-//@[012:00025) |   |   | ├─IdentifierSyntax
-//@[012:00025) |   |   | | └─Token(Identifier) |resourceGroup|
-//@[025:00026) |   |   | ├─Token(LeftParen) |(|
-//@[026:00027) |   |   | └─Token(RightParen) |)|
-//@[027:00028) |   |   ├─Token(Dot) |.|
-//@[028:00036) |   |   └─IdentifierSyntax
-//@[028:00036) |   |     └─Token(Identifier) |location|
-//@[036:00038) |   ├─Token(NewLine) |\r\n|
   name: 'myVnet'
-//@[002:00016) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00016) |   | └─StringSyntax
-//@[008:00016) |   |   └─Token(StringComplete) |'myVnet'|
-//@[016:00018) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00106) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00106) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     addressSpace: {
-//@[004:00084) |   |   ├─ObjectPropertySyntax
-//@[004:00016) |   |   | ├─IdentifierSyntax
-//@[004:00016) |   |   | | └─Token(Identifier) |addressSpace|
-//@[016:00017) |   |   | ├─Token(Colon) |:|
-//@[018:00084) |   |   | └─ObjectSyntax
-//@[018:00019) |   |   |   ├─Token(LeftBrace) |{|
-//@[019:00021) |   |   |   ├─Token(NewLine) |\r\n|
       addressPrefixes: [
-//@[006:00056) |   |   |   ├─ObjectPropertySyntax
-//@[006:00021) |   |   |   | ├─IdentifierSyntax
-//@[006:00021) |   |   |   | | └─Token(Identifier) |addressPrefixes|
-//@[021:00022) |   |   |   | ├─Token(Colon) |:|
-//@[023:00056) |   |   |   | └─ArraySyntax
-//@[023:00024) |   |   |   |   ├─Token(LeftSquare) |[|
-//@[024:00026) |   |   |   |   ├─Token(NewLine) |\r\n|
         '10.0.0.0/20'
-//@[008:00021) |   |   |   |   ├─ArrayItemSyntax
-//@[008:00021) |   |   |   |   | └─StringSyntax
-//@[008:00021) |   |   |   |   |   └─Token(StringComplete) |'10.0.0.0/20'|
-//@[021:00023) |   |   |   |   ├─Token(NewLine) |\r\n|
       ]
-//@[006:00007) |   |   |   |   └─Token(RightSquare) |]|
-//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
     }
-//@[004:00005) |   |   |   └─Token(RightBrace) |}|
-//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource p1_subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@[000:00175) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00019) | ├─IdentifierSyntax
-//@[009:00019) | | └─Token(Identifier) |p1_subnet1|
-//@[020:00074) | ├─StringSyntax
-//@[020:00074) | | └─Token(StringComplete) |'Microsoft.Network/virtualNetworks/subnets@2020-06-01'|
-//@[075:00076) | ├─Token(Assignment) |=|
-//@[077:00175) | └─ObjectSyntax
-//@[077:00078) |   ├─Token(LeftBrace) |{|
-//@[078:00080) |   ├─Token(NewLine) |\r\n|
   parent: p1_vnet
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00008) |   | ├─IdentifierSyntax
-//@[002:00008) |   | | └─Token(Identifier) |parent|
-//@[008:00009) |   | ├─Token(Colon) |:|
-//@[010:00017) |   | └─VariableAccessSyntax
-//@[010:00017) |   |   └─IdentifierSyntax
-//@[010:00017) |   |     └─Token(Identifier) |p1_vnet|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   name: 'subnet1'
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00017) |   | └─StringSyntax
-//@[008:00017) |   |   └─Token(StringComplete) |'subnet1'|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00054) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00054) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     addressPrefix: '10.0.0.0/24'
-//@[004:00032) |   |   ├─ObjectPropertySyntax
-//@[004:00017) |   |   | ├─IdentifierSyntax
-//@[004:00017) |   |   | | └─Token(Identifier) |addressPrefix|
-//@[017:00018) |   |   | ├─Token(Colon) |:|
-//@[019:00032) |   |   | └─StringSyntax
-//@[019:00032) |   |   |   └─Token(StringComplete) |'10.0.0.0/24'|
-//@[032:00034) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource p1_subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@[000:00175) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00019) | ├─IdentifierSyntax
-//@[009:00019) | | └─Token(Identifier) |p1_subnet2|
-//@[020:00074) | ├─StringSyntax
-//@[020:00074) | | └─Token(StringComplete) |'Microsoft.Network/virtualNetworks/subnets@2020-06-01'|
-//@[075:00076) | ├─Token(Assignment) |=|
-//@[077:00175) | └─ObjectSyntax
-//@[077:00078) |   ├─Token(LeftBrace) |{|
-//@[078:00080) |   ├─Token(NewLine) |\r\n|
   parent: p1_vnet
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00008) |   | ├─IdentifierSyntax
-//@[002:00008) |   | | └─Token(Identifier) |parent|
-//@[008:00009) |   | ├─Token(Colon) |:|
-//@[010:00017) |   | └─VariableAccessSyntax
-//@[010:00017) |   |   └─IdentifierSyntax
-//@[010:00017) |   |     └─Token(Identifier) |p1_vnet|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   name: 'subnet2'
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00017) |   | └─StringSyntax
-//@[008:00017) |   |   └─Token(StringComplete) |'subnet2'|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   properties: {
-//@[002:00054) |   ├─ObjectPropertySyntax
-//@[002:00012) |   | ├─IdentifierSyntax
-//@[002:00012) |   | | └─Token(Identifier) |properties|
-//@[012:00013) |   | ├─Token(Colon) |:|
-//@[014:00054) |   | └─ObjectSyntax
-//@[014:00015) |   |   ├─Token(LeftBrace) |{|
-//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
     addressPrefix: '10.0.1.0/24'
-//@[004:00032) |   |   ├─ObjectPropertySyntax
-//@[004:00017) |   |   | ├─IdentifierSyntax
-//@[004:00017) |   |   | | └─Token(Identifier) |addressPrefix|
-//@[017:00018) |   |   | ├─Token(Colon) |:|
-//@[019:00032) |   |   | └─StringSyntax
-//@[019:00032) |   |   |   └─Token(StringComplete) |'10.0.1.0/24'|
-//@[032:00034) |   |   ├─Token(NewLine) |\r\n|
   }
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 output p1_subnet1prefix string = p1_subnet1.properties.addressPrefix
-//@[000:00068) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p1_subnet1prefix|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00068) | └─PropertyAccessSyntax
-//@[033:00054) |   ├─PropertyAccessSyntax
-//@[033:00043) |   | ├─VariableAccessSyntax
-//@[033:00043) |   | | └─IdentifierSyntax
-//@[033:00043) |   | |   └─Token(Identifier) |p1_subnet1|
-//@[043:00044) |   | ├─Token(Dot) |.|
-//@[044:00054) |   | └─IdentifierSyntax
-//@[044:00054) |   |   └─Token(Identifier) |properties|
-//@[054:00055) |   ├─Token(Dot) |.|
-//@[055:00068) |   └─IdentifierSyntax
-//@[055:00068) |     └─Token(Identifier) |addressPrefix|
-//@[068:00070) ├─Token(NewLine) |\r\n|
 output p1_subnet1name string = p1_subnet1.name
-//@[000:00046) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00021) | ├─IdentifierSyntax
-//@[007:00021) | | └─Token(Identifier) |p1_subnet1name|
-//@[022:00028) | ├─TypeVariableAccessSyntax
-//@[022:00028) | | └─IdentifierSyntax
-//@[022:00028) | |   └─Token(Identifier) |string|
-//@[029:00030) | ├─Token(Assignment) |=|
-//@[031:00046) | └─PropertyAccessSyntax
-//@[031:00041) |   ├─VariableAccessSyntax
-//@[031:00041) |   | └─IdentifierSyntax
-//@[031:00041) |   |   └─Token(Identifier) |p1_subnet1|
-//@[041:00042) |   ├─Token(Dot) |.|
-//@[042:00046) |   └─IdentifierSyntax
-//@[042:00046) |     └─Token(Identifier) |name|
-//@[046:00048) ├─Token(NewLine) |\r\n|
 output p1_subnet1type string = p1_subnet1.type
-//@[000:00046) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00021) | ├─IdentifierSyntax
-//@[007:00021) | | └─Token(Identifier) |p1_subnet1type|
-//@[022:00028) | ├─TypeVariableAccessSyntax
-//@[022:00028) | | └─IdentifierSyntax
-//@[022:00028) | |   └─Token(Identifier) |string|
-//@[029:00030) | ├─Token(Assignment) |=|
-//@[031:00046) | └─PropertyAccessSyntax
-//@[031:00041) |   ├─VariableAccessSyntax
-//@[031:00041) |   | └─IdentifierSyntax
-//@[031:00041) |   |   └─Token(Identifier) |p1_subnet1|
-//@[041:00042) |   ├─Token(Dot) |.|
-//@[042:00046) |   └─IdentifierSyntax
-//@[042:00046) |     └─Token(Identifier) |type|
-//@[046:00048) ├─Token(NewLine) |\r\n|
 output p1_subnet1id string = p1_subnet1.id
-//@[000:00042) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00019) | ├─IdentifierSyntax
-//@[007:00019) | | └─Token(Identifier) |p1_subnet1id|
-//@[020:00026) | ├─TypeVariableAccessSyntax
-//@[020:00026) | | └─IdentifierSyntax
-//@[020:00026) | |   └─Token(Identifier) |string|
-//@[027:00028) | ├─Token(Assignment) |=|
-//@[029:00042) | └─PropertyAccessSyntax
-//@[029:00039) |   ├─VariableAccessSyntax
-//@[029:00039) |   | └─IdentifierSyntax
-//@[029:00039) |   |   └─Token(Identifier) |p1_subnet1|
-//@[039:00040) |   ├─Token(Dot) |.|
-//@[040:00042) |   └─IdentifierSyntax
-//@[040:00042) |     └─Token(Identifier) |id|
-//@[042:00046) ├─Token(NewLine) |\r\n\r\n|
 
 // parent property with extension resource
-//@[042:00044) ├─Token(NewLine) |\r\n|
 resource p2_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
-//@[000:00076) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00016) | ├─IdentifierSyntax
-//@[009:00016) | | └─Token(Identifier) |p2_res1|
-//@[017:00053) | ├─StringSyntax
-//@[017:00053) | | └─Token(StringComplete) |'Microsoft.Rp1/resource1@2020-06-01'|
-//@[054:00055) | ├─Token(Assignment) |=|
-//@[056:00076) | └─ObjectSyntax
-//@[056:00057) |   ├─Token(LeftBrace) |{|
-//@[057:00059) |   ├─Token(NewLine) |\r\n|
   name: 'res1'
-//@[002:00014) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00014) |   | └─StringSyntax
-//@[008:00014) |   |   └─Token(StringComplete) |'res1'|
-//@[014:00016) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource p2_res1child 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[000:00109) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00021) | ├─IdentifierSyntax
-//@[009:00021) | | └─Token(Identifier) |p2_res1child|
-//@[022:00065) | ├─StringSyntax
-//@[022:00065) | | └─Token(StringComplete) |'Microsoft.Rp1/resource1/child1@2020-06-01'|
-//@[066:00067) | ├─Token(Assignment) |=|
-//@[068:00109) | └─ObjectSyntax
-//@[068:00069) |   ├─Token(LeftBrace) |{|
-//@[069:00071) |   ├─Token(NewLine) |\r\n|
   parent: p2_res1
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00008) |   | ├─IdentifierSyntax
-//@[002:00008) |   | | └─Token(Identifier) |parent|
-//@[008:00009) |   | ├─Token(Colon) |:|
-//@[010:00017) |   | └─VariableAccessSyntax
-//@[010:00017) |   |   └─IdentifierSyntax
-//@[010:00017) |   |     └─Token(Identifier) |p2_res1|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   name: 'child1'
-//@[002:00016) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00016) |   | └─StringSyntax
-//@[008:00016) |   |   └─Token(StringComplete) |'child1'|
-//@[016:00018) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource p2_res2 'Microsoft.Rp2/resource2@2020-06-01' = {
-//@[000:00099) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00016) | ├─IdentifierSyntax
-//@[009:00016) | | └─Token(Identifier) |p2_res2|
-//@[017:00053) | ├─StringSyntax
-//@[017:00053) | | └─Token(StringComplete) |'Microsoft.Rp2/resource2@2020-06-01'|
-//@[054:00055) | ├─Token(Assignment) |=|
-//@[056:00099) | └─ObjectSyntax
-//@[056:00057) |   ├─Token(LeftBrace) |{|
-//@[057:00059) |   ├─Token(NewLine) |\r\n|
   scope: p2_res1child
-//@[002:00021) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |scope|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00021) |   | └─VariableAccessSyntax
-//@[009:00021) |   |   └─IdentifierSyntax
-//@[009:00021) |   |     └─Token(Identifier) |p2_res1child|
-//@[021:00023) |   ├─Token(NewLine) |\r\n|
   name: 'res2'
-//@[002:00014) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00014) |   | └─StringSyntax
-//@[008:00014) |   |   └─Token(StringComplete) |'res2'|
-//@[014:00016) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
-//@[000:00109) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00021) | ├─IdentifierSyntax
-//@[009:00021) | | └─Token(Identifier) |p2_res2child|
-//@[022:00065) | ├─StringSyntax
-//@[022:00065) | | └─Token(StringComplete) |'Microsoft.Rp2/resource2/child2@2020-06-01'|
-//@[066:00067) | ├─Token(Assignment) |=|
-//@[068:00109) | └─ObjectSyntax
-//@[068:00069) |   ├─Token(LeftBrace) |{|
-//@[069:00071) |   ├─Token(NewLine) |\r\n|
   parent: p2_res2
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00008) |   | ├─IdentifierSyntax
-//@[002:00008) |   | | └─Token(Identifier) |parent|
-//@[008:00009) |   | ├─Token(Colon) |:|
-//@[010:00017) |   | └─VariableAccessSyntax
-//@[010:00017) |   |   └─IdentifierSyntax
-//@[010:00017) |   |     └─Token(Identifier) |p2_res2|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   name: 'child2'
-//@[002:00016) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00016) |   | └─StringSyntax
-//@[008:00016) |   |   └─Token(StringComplete) |'child2'|
-//@[016:00018) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 output p2_res2childprop string = p2_res2child.properties.someProp
-//@[000:00065) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p2_res2childprop|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00065) | └─PropertyAccessSyntax
-//@[033:00056) |   ├─PropertyAccessSyntax
-//@[033:00045) |   | ├─VariableAccessSyntax
-//@[033:00045) |   | | └─IdentifierSyntax
-//@[033:00045) |   | |   └─Token(Identifier) |p2_res2child|
-//@[045:00046) |   | ├─Token(Dot) |.|
-//@[046:00056) |   | └─IdentifierSyntax
-//@[046:00056) |   |   └─Token(Identifier) |properties|
-//@[056:00057) |   ├─Token(Dot) |.|
-//@[057:00065) |   └─IdentifierSyntax
-//@[057:00065) |     └─Token(Identifier) |someProp|
-//@[065:00067) ├─Token(NewLine) |\r\n|
 output p2_res2childname string = p2_res2child.name
-//@[000:00050) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p2_res2childname|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00050) | └─PropertyAccessSyntax
-//@[033:00045) |   ├─VariableAccessSyntax
-//@[033:00045) |   | └─IdentifierSyntax
-//@[033:00045) |   |   └─Token(Identifier) |p2_res2child|
-//@[045:00046) |   ├─Token(Dot) |.|
-//@[046:00050) |   └─IdentifierSyntax
-//@[046:00050) |     └─Token(Identifier) |name|
-//@[050:00052) ├─Token(NewLine) |\r\n|
 output p2_res2childtype string = p2_res2child.type
-//@[000:00050) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p2_res2childtype|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00050) | └─PropertyAccessSyntax
-//@[033:00045) |   ├─VariableAccessSyntax
-//@[033:00045) |   | └─IdentifierSyntax
-//@[033:00045) |   |   └─Token(Identifier) |p2_res2child|
-//@[045:00046) |   ├─Token(Dot) |.|
-//@[046:00050) |   └─IdentifierSyntax
-//@[046:00050) |     └─Token(Identifier) |type|
-//@[050:00052) ├─Token(NewLine) |\r\n|
 output p2_res2childid string = p2_res2child.id
-//@[000:00046) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00021) | ├─IdentifierSyntax
-//@[007:00021) | | └─Token(Identifier) |p2_res2childid|
-//@[022:00028) | ├─TypeVariableAccessSyntax
-//@[022:00028) | | └─IdentifierSyntax
-//@[022:00028) | |   └─Token(Identifier) |string|
-//@[029:00030) | ├─Token(Assignment) |=|
-//@[031:00046) | └─PropertyAccessSyntax
-//@[031:00043) |   ├─VariableAccessSyntax
-//@[031:00043) |   | └─IdentifierSyntax
-//@[031:00043) |   |   └─Token(Identifier) |p2_res2child|
-//@[043:00044) |   ├─Token(Dot) |.|
-//@[044:00046) |   └─IdentifierSyntax
-//@[044:00046) |     └─Token(Identifier) |id|
-//@[046:00050) ├─Token(NewLine) |\r\n\r\n|
 
 // parent property with 'existing' resource
-//@[043:00045) ├─Token(NewLine) |\r\n|
 resource p3_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[000:00085) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00016) | ├─IdentifierSyntax
-//@[009:00016) | | └─Token(Identifier) |p3_res1|
-//@[017:00053) | ├─StringSyntax
-//@[017:00053) | | └─Token(StringComplete) |'Microsoft.Rp1/resource1@2020-06-01'|
-//@[054:00062) | ├─Token(Identifier) |existing|
-//@[063:00064) | ├─Token(Assignment) |=|
-//@[065:00085) | └─ObjectSyntax
-//@[065:00066) |   ├─Token(LeftBrace) |{|
-//@[066:00068) |   ├─Token(NewLine) |\r\n|
   name: 'res1'
-//@[002:00014) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00014) |   | └─StringSyntax
-//@[008:00014) |   |   └─Token(StringComplete) |'res1'|
-//@[014:00016) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource p3_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[000:00106) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |p3_child1|
-//@[019:00062) | ├─StringSyntax
-//@[019:00062) | | └─Token(StringComplete) |'Microsoft.Rp1/resource1/child1@2020-06-01'|
-//@[063:00064) | ├─Token(Assignment) |=|
-//@[065:00106) | └─ObjectSyntax
-//@[065:00066) |   ├─Token(LeftBrace) |{|
-//@[066:00068) |   ├─Token(NewLine) |\r\n|
   parent: p3_res1
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00008) |   | ├─IdentifierSyntax
-//@[002:00008) |   | | └─Token(Identifier) |parent|
-//@[008:00009) |   | ├─Token(Colon) |:|
-//@[010:00017) |   | └─VariableAccessSyntax
-//@[010:00017) |   |   └─IdentifierSyntax
-//@[010:00017) |   |     └─Token(Identifier) |p3_res1|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   name: 'child1'
-//@[002:00016) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00016) |   | └─StringSyntax
-//@[008:00016) |   |   └─Token(StringComplete) |'child1'|
-//@[016:00018) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 output p3_res1childprop string = p3_child1.properties.someProp
-//@[000:00062) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p3_res1childprop|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00062) | └─PropertyAccessSyntax
-//@[033:00053) |   ├─PropertyAccessSyntax
-//@[033:00042) |   | ├─VariableAccessSyntax
-//@[033:00042) |   | | └─IdentifierSyntax
-//@[033:00042) |   | |   └─Token(Identifier) |p3_child1|
-//@[042:00043) |   | ├─Token(Dot) |.|
-//@[043:00053) |   | └─IdentifierSyntax
-//@[043:00053) |   |   └─Token(Identifier) |properties|
-//@[053:00054) |   ├─Token(Dot) |.|
-//@[054:00062) |   └─IdentifierSyntax
-//@[054:00062) |     └─Token(Identifier) |someProp|
-//@[062:00064) ├─Token(NewLine) |\r\n|
 output p3_res1childname string = p3_child1.name
-//@[000:00047) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p3_res1childname|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00047) | └─PropertyAccessSyntax
-//@[033:00042) |   ├─VariableAccessSyntax
-//@[033:00042) |   | └─IdentifierSyntax
-//@[033:00042) |   |   └─Token(Identifier) |p3_child1|
-//@[042:00043) |   ├─Token(Dot) |.|
-//@[043:00047) |   └─IdentifierSyntax
-//@[043:00047) |     └─Token(Identifier) |name|
-//@[047:00049) ├─Token(NewLine) |\r\n|
 output p3_res1childtype string = p3_child1.type
-//@[000:00047) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p3_res1childtype|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00047) | └─PropertyAccessSyntax
-//@[033:00042) |   ├─VariableAccessSyntax
-//@[033:00042) |   | └─IdentifierSyntax
-//@[033:00042) |   |   └─Token(Identifier) |p3_child1|
-//@[042:00043) |   ├─Token(Dot) |.|
-//@[043:00047) |   └─IdentifierSyntax
-//@[043:00047) |     └─Token(Identifier) |type|
-//@[047:00049) ├─Token(NewLine) |\r\n|
 output p3_res1childid string = p3_child1.id
-//@[000:00043) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00021) | ├─IdentifierSyntax
-//@[007:00021) | | └─Token(Identifier) |p3_res1childid|
-//@[022:00028) | ├─TypeVariableAccessSyntax
-//@[022:00028) | | └─IdentifierSyntax
-//@[022:00028) | |   └─Token(Identifier) |string|
-//@[029:00030) | ├─Token(Assignment) |=|
-//@[031:00043) | └─PropertyAccessSyntax
-//@[031:00040) |   ├─VariableAccessSyntax
-//@[031:00040) |   | └─IdentifierSyntax
-//@[031:00040) |   |   └─Token(Identifier) |p3_child1|
-//@[040:00041) |   ├─Token(Dot) |.|
-//@[041:00043) |   └─IdentifierSyntax
-//@[041:00043) |     └─Token(Identifier) |id|
-//@[043:00047) ├─Token(NewLine) |\r\n\r\n|
 
 // parent & child with 'existing'
-//@[033:00035) ├─Token(NewLine) |\r\n|
 resource p4_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[000:00104) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00016) | ├─IdentifierSyntax
-//@[009:00016) | | └─Token(Identifier) |p4_res1|
-//@[017:00053) | ├─StringSyntax
-//@[017:00053) | | └─Token(StringComplete) |'Microsoft.Rp1/resource1@2020-06-01'|
-//@[054:00062) | ├─Token(Identifier) |existing|
-//@[063:00064) | ├─Token(Assignment) |=|
-//@[065:00104) | └─ObjectSyntax
-//@[065:00066) |   ├─Token(LeftBrace) |{|
-//@[066:00068) |   ├─Token(NewLine) |\r\n|
   scope: tenant()
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00007) |   | ├─IdentifierSyntax
-//@[002:00007) |   | | └─Token(Identifier) |scope|
-//@[007:00008) |   | ├─Token(Colon) |:|
-//@[009:00017) |   | └─FunctionCallSyntax
-//@[009:00015) |   |   ├─IdentifierSyntax
-//@[009:00015) |   |   | └─Token(Identifier) |tenant|
-//@[015:00016) |   |   ├─Token(LeftParen) |(|
-//@[016:00017) |   |   └─Token(RightParen) |)|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   name: 'res1'
-//@[002:00014) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00014) |   | └─StringSyntax
-//@[008:00014) |   |   └─Token(StringComplete) |'res1'|
-//@[014:00016) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 resource p4_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' existing = {
-//@[000:00115) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |p4_child1|
-//@[019:00062) | ├─StringSyntax
-//@[019:00062) | | └─Token(StringComplete) |'Microsoft.Rp1/resource1/child1@2020-06-01'|
-//@[063:00071) | ├─Token(Identifier) |existing|
-//@[072:00073) | ├─Token(Assignment) |=|
-//@[074:00115) | └─ObjectSyntax
-//@[074:00075) |   ├─Token(LeftBrace) |{|
-//@[075:00077) |   ├─Token(NewLine) |\r\n|
   parent: p4_res1
-//@[002:00017) |   ├─ObjectPropertySyntax
-//@[002:00008) |   | ├─IdentifierSyntax
-//@[002:00008) |   | | └─Token(Identifier) |parent|
-//@[008:00009) |   | ├─Token(Colon) |:|
-//@[010:00017) |   | └─VariableAccessSyntax
-//@[010:00017) |   |   └─IdentifierSyntax
-//@[010:00017) |   |     └─Token(Identifier) |p4_res1|
-//@[017:00019) |   ├─Token(NewLine) |\r\n|
   name: 'child1'
-//@[002:00016) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00016) |   | └─StringSyntax
-//@[008:00016) |   |   └─Token(StringComplete) |'child1'|
-//@[016:00018) |   ├─Token(NewLine) |\r\n|
 }
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
 output p4_res1childprop string = p4_child1.properties.someProp
-//@[000:00062) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p4_res1childprop|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00062) | └─PropertyAccessSyntax
-//@[033:00053) |   ├─PropertyAccessSyntax
-//@[033:00042) |   | ├─VariableAccessSyntax
-//@[033:00042) |   | | └─IdentifierSyntax
-//@[033:00042) |   | |   └─Token(Identifier) |p4_child1|
-//@[042:00043) |   | ├─Token(Dot) |.|
-//@[043:00053) |   | └─IdentifierSyntax
-//@[043:00053) |   |   └─Token(Identifier) |properties|
-//@[053:00054) |   ├─Token(Dot) |.|
-//@[054:00062) |   └─IdentifierSyntax
-//@[054:00062) |     └─Token(Identifier) |someProp|
-//@[062:00064) ├─Token(NewLine) |\r\n|
 output p4_res1childname string = p4_child1.name
-//@[000:00047) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p4_res1childname|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00047) | └─PropertyAccessSyntax
-//@[033:00042) |   ├─VariableAccessSyntax
-//@[033:00042) |   | └─IdentifierSyntax
-//@[033:00042) |   |   └─Token(Identifier) |p4_child1|
-//@[042:00043) |   ├─Token(Dot) |.|
-//@[043:00047) |   └─IdentifierSyntax
-//@[043:00047) |     └─Token(Identifier) |name|
-//@[047:00049) ├─Token(NewLine) |\r\n|
 output p4_res1childtype string = p4_child1.type
-//@[000:00047) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00023) | ├─IdentifierSyntax
-//@[007:00023) | | └─Token(Identifier) |p4_res1childtype|
-//@[024:00030) | ├─TypeVariableAccessSyntax
-//@[024:00030) | | └─IdentifierSyntax
-//@[024:00030) | |   └─Token(Identifier) |string|
-//@[031:00032) | ├─Token(Assignment) |=|
-//@[033:00047) | └─PropertyAccessSyntax
-//@[033:00042) |   ├─VariableAccessSyntax
-//@[033:00042) |   | └─IdentifierSyntax
-//@[033:00042) |   |   └─Token(Identifier) |p4_child1|
-//@[042:00043) |   ├─Token(Dot) |.|
-//@[043:00047) |   └─IdentifierSyntax
-//@[043:00047) |     └─Token(Identifier) |type|
-//@[047:00049) ├─Token(NewLine) |\r\n|
 output p4_res1childid string = p4_child1.id
-//@[000:00043) ├─OutputDeclarationSyntax
-//@[000:00006) | ├─Token(Identifier) |output|
-//@[007:00021) | ├─IdentifierSyntax
-//@[007:00021) | | └─Token(Identifier) |p4_res1childid|
-//@[022:00028) | ├─TypeVariableAccessSyntax
-//@[022:00028) | | └─IdentifierSyntax
-//@[022:00028) | |   └─Token(Identifier) |string|
-//@[029:00030) | ├─Token(Assignment) |=|
-//@[031:00043) | └─PropertyAccessSyntax
-//@[031:00040) |   ├─VariableAccessSyntax
-//@[031:00040) |   | └─IdentifierSyntax
-//@[031:00040) |   |   └─Token(Identifier) |p4_child1|
-//@[040:00041) |   ├─Token(Dot) |.|
-//@[041:00043) |   └─IdentifierSyntax
-//@[041:00043) |     └─Token(Identifier) |id|
-//@[043:00047) ├─Token(NewLine) |\r\n\r\n|
 
 // parent & nested child with decorators https://github.com/Azure/bicep/issues/10970
-//@[084:00086) ├─Token(NewLine) |\r\n|
 var dbs = ['db1', 'db2','db3']
-//@[000:00030) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00007) | ├─IdentifierSyntax
-//@[004:00007) | | └─Token(Identifier) |dbs|
-//@[008:00009) | ├─Token(Assignment) |=|
-//@[010:00030) | └─ArraySyntax
-//@[010:00011) |   ├─Token(LeftSquare) |[|
-//@[011:00016) |   ├─ArrayItemSyntax
-//@[011:00016) |   | └─StringSyntax
-//@[011:00016) |   |   └─Token(StringComplete) |'db1'|
-//@[016:00017) |   ├─Token(Comma) |,|
-//@[018:00023) |   ├─ArrayItemSyntax
-//@[018:00023) |   | └─StringSyntax
-//@[018:00023) |   |   └─Token(StringComplete) |'db2'|
-//@[023:00024) |   ├─Token(Comma) |,|
-//@[024:00029) |   ├─ArrayItemSyntax
-//@[024:00029) |   | └─StringSyntax
-//@[024:00029) |   |   └─Token(StringComplete) |'db3'|
-//@[029:00030) |   └─Token(RightSquare) |]|
-//@[030:00032) ├─Token(NewLine) |\r\n|
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
-//@[000:00572) ├─ResourceDeclarationSyntax
-//@[000:00008) | ├─Token(Identifier) |resource|
-//@[009:00018) | ├─IdentifierSyntax
-//@[009:00018) | | └─Token(Identifier) |sqlServer|
-//@[019:00053) | ├─StringSyntax
-//@[019:00053) | | └─Token(StringComplete) |'Microsoft.Sql/servers@2021-11-01'|
-//@[054:00055) | ├─Token(Assignment) |=|
-//@[056:00572) | └─ObjectSyntax
-//@[056:00057) |   ├─Token(LeftBrace) |{|
-//@[057:00059) |   ├─Token(NewLine) |\r\n|
   name: 'sql-server-name'
-//@[002:00025) |   ├─ObjectPropertySyntax
-//@[002:00006) |   | ├─IdentifierSyntax
-//@[002:00006) |   | | └─Token(Identifier) |name|
-//@[006:00007) |   | ├─Token(Colon) |:|
-//@[008:00025) |   | └─StringSyntax
-//@[008:00025) |   |   └─Token(StringComplete) |'sql-server-name'|
-//@[025:00027) |   ├─Token(NewLine) |\r\n|
   location: 'polandcentral'
-//@[002:00027) |   ├─ObjectPropertySyntax
-//@[002:00010) |   | ├─IdentifierSyntax
-//@[002:00010) |   | | └─Token(Identifier) |location|
-//@[010:00011) |   | ├─Token(Colon) |:|
-//@[012:00027) |   | └─StringSyntax
-//@[012:00027) |   |   └─Token(StringComplete) |'polandcentral'|
-//@[027:00031) |   ├─Token(NewLine) |\r\n\r\n|
 
   @batchSize(1)
-//@[002:00156) |   ├─ResourceDeclarationSyntax
-//@[002:00015) |   | ├─DecoratorSyntax
-//@[002:00003) |   | | ├─Token(At) |@|
-//@[003:00015) |   | | └─FunctionCallSyntax
-//@[003:00012) |   | |   ├─IdentifierSyntax
-//@[003:00012) |   | |   | └─Token(Identifier) |batchSize|
-//@[012:00013) |   | |   ├─Token(LeftParen) |(|
-//@[013:00014) |   | |   ├─FunctionArgumentSyntax
-//@[013:00014) |   | |   | └─IntegerLiteralSyntax
-//@[013:00014) |   | |   |   └─Token(Integer) |1|
-//@[014:00015) |   | |   └─Token(RightParen) |)|
-//@[015:00017) |   | ├─Token(NewLine) |\r\n|
   @description('Sql Databases')
-//@[002:00031) |   | ├─DecoratorSyntax
-//@[002:00003) |   | | ├─Token(At) |@|
-//@[003:00031) |   | | └─FunctionCallSyntax
-//@[003:00014) |   | |   ├─IdentifierSyntax
-//@[003:00014) |   | |   | └─Token(Identifier) |description|
-//@[014:00015) |   | |   ├─Token(LeftParen) |(|
-//@[015:00030) |   | |   ├─FunctionArgumentSyntax
-//@[015:00030) |   | |   | └─StringSyntax
-//@[015:00030) |   | |   |   └─Token(StringComplete) |'Sql Databases'|
-//@[030:00031) |   | |   └─Token(RightParen) |)|
-//@[031:00033) |   | ├─Token(NewLine) |\r\n|
   resource sqlDatabases 'databases' = [for db in dbs: {
-//@[002:00010) |   | ├─Token(Identifier) |resource|
-//@[011:00023) |   | ├─IdentifierSyntax
-//@[011:00023) |   | | └─Token(Identifier) |sqlDatabases|
-//@[024:00035) |   | ├─StringSyntax
-//@[024:00035) |   | | └─Token(StringComplete) |'databases'|
-//@[036:00037) |   | ├─Token(Assignment) |=|
-//@[038:00106) |   | └─ForSyntax
-//@[038:00039) |   |   ├─Token(LeftSquare) |[|
-//@[039:00042) |   |   ├─Token(Identifier) |for|
-//@[043:00045) |   |   ├─LocalVariableSyntax
-//@[043:00045) |   |   | └─IdentifierSyntax
-//@[043:00045) |   |   |   └─Token(Identifier) |db|
-//@[046:00048) |   |   ├─Token(Identifier) |in|
-//@[049:00052) |   |   ├─VariableAccessSyntax
-//@[049:00052) |   |   | └─IdentifierSyntax
-//@[049:00052) |   |   |   └─Token(Identifier) |dbs|
-//@[052:00053) |   |   ├─Token(Colon) |:|
-//@[054:00105) |   |   ├─ObjectSyntax
-//@[054:00055) |   |   | ├─Token(LeftBrace) |{|
-//@[055:00057) |   |   | ├─Token(NewLine) |\r\n|
     name: db
-//@[004:00012) |   |   | ├─ObjectPropertySyntax
-//@[004:00008) |   |   | | ├─IdentifierSyntax
-//@[004:00008) |   |   | | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | | ├─Token(Colon) |:|
-//@[010:00012) |   |   | | └─VariableAccessSyntax
-//@[010:00012) |   |   | |   └─IdentifierSyntax
-//@[010:00012) |   |   | |     └─Token(Identifier) |db|
-//@[012:00014) |   |   | ├─Token(NewLine) |\r\n|
     location: 'polandcentral'
-//@[004:00029) |   |   | ├─ObjectPropertySyntax
-//@[004:00012) |   |   | | ├─IdentifierSyntax
-//@[004:00012) |   |   | | | └─Token(Identifier) |location|
-//@[012:00013) |   |   | | ├─Token(Colon) |:|
-//@[014:00029) |   |   | | └─StringSyntax
-//@[014:00029) |   |   | |   └─Token(StringComplete) |'polandcentral'|
-//@[029:00031) |   |   | ├─Token(NewLine) |\r\n|
   }]
-//@[002:00003) |   |   | └─Token(RightBrace) |}|
-//@[003:00004) |   |   └─Token(RightSquare) |]|
-//@[004:00008) |   ├─Token(NewLine) |\r\n\r\n|
 
   @description('Primary Sql Database')
-//@[002:00292) |   ├─ResourceDeclarationSyntax
-//@[002:00038) |   | ├─DecoratorSyntax
-//@[002:00003) |   | | ├─Token(At) |@|
-//@[003:00038) |   | | └─FunctionCallSyntax
-//@[003:00014) |   | |   ├─IdentifierSyntax
-//@[003:00014) |   | |   | └─Token(Identifier) |description|
-//@[014:00015) |   | |   ├─Token(LeftParen) |(|
-//@[015:00037) |   | |   ├─FunctionArgumentSyntax
-//@[015:00037) |   | |   | └─StringSyntax
-//@[015:00037) |   | |   |   └─Token(StringComplete) |'Primary Sql Database'|
-//@[037:00038) |   | |   └─Token(RightParen) |)|
-//@[038:00040) |   | ├─Token(NewLine) |\r\n|
   resource primaryDb 'databases' = {
-//@[002:00010) |   | ├─Token(Identifier) |resource|
-//@[011:00020) |   | ├─IdentifierSyntax
-//@[011:00020) |   | | └─Token(Identifier) |primaryDb|
-//@[021:00032) |   | ├─StringSyntax
-//@[021:00032) |   | | └─Token(StringComplete) |'databases'|
-//@[033:00034) |   | ├─Token(Assignment) |=|
-//@[035:00252) |   | └─ObjectSyntax
-//@[035:00036) |   |   ├─Token(LeftBrace) |{|
-//@[036:00038) |   |   ├─Token(NewLine) |\r\n|
     name: 'primary-db'
-//@[004:00022) |   |   ├─ObjectPropertySyntax
-//@[004:00008) |   |   | ├─IdentifierSyntax
-//@[004:00008) |   |   | | └─Token(Identifier) |name|
-//@[008:00009) |   |   | ├─Token(Colon) |:|
-//@[010:00022) |   |   | └─StringSyntax
-//@[010:00022) |   |   |   └─Token(StringComplete) |'primary-db'|
-//@[022:00024) |   |   ├─Token(NewLine) |\r\n|
     location: 'polandcentral'
 
     resource threatProtection 'advancedThreatProtectionSettings' = {
-//@[004:00029) |   |   ├─ObjectPropertySyntax
-//@[004:00012) |   |   | ├─IdentifierSyntax
-//@[004:00012) |   |   | | └─Token(Identifier) |location|
-//@[012:00013) |   |   | ├─Token(Colon) |:|
-//@[014:00029) |   |   | └─StringSyntax
-//@[014:00029) |   |   |   └─Token(StringComplete) |'polandcentral'|
-//@[029:00031) |   |   ├─Token(NewLine) |\n\n|
       name: 'Default'
       properties: {
-//@[004:00154) |   |   ├─ResourceDeclarationSyntax
-//@[004:00012) |   |   | ├─Token(Identifier) |resource|
-//@[013:00029) |   |   | ├─IdentifierSyntax
-//@[013:00029) |   |   | | └─Token(Identifier) |threatProtection|
-//@[030:00064) |   |   | ├─StringSyntax
-//@[030:00064) |   |   | | └─Token(StringComplete) |'advancedThreatProtectionSettings'|
-//@[065:00066) |   |   | ├─Token(Assignment) |=|
-//@[067:00154) |   |   | └─ObjectSyntax
-//@[067:00068) |   |   |   ├─Token(LeftBrace) |{|
-//@[068:00070) |   |   |   ├─Token(NewLine) |\r\n|
         state: 'Enabled'
-//@[006:00021) |   |   |   ├─ObjectPropertySyntax
-//@[006:00010) |   |   |   | ├─IdentifierSyntax
-//@[006:00010) |   |   |   | | └─Token(Identifier) |name|
-//@[010:00011) |   |   |   | ├─Token(Colon) |:|
-//@[012:00021) |   |   |   | └─StringSyntax
-//@[012:00021) |   |   |   |   └─Token(StringComplete) |'Default'|
-//@[021:00023) |   |   |   ├─Token(NewLine) |\r\n|
       }
-//@[006:00054) |   |   |   ├─ObjectPropertySyntax
-//@[006:00016) |   |   |   | ├─IdentifierSyntax
-//@[006:00016) |   |   |   | | └─Token(Identifier) |properties|
-//@[016:00017) |   |   |   | ├─Token(Colon) |:|
-//@[018:00054) |   |   |   | └─ObjectSyntax
-//@[018:00019) |   |   |   |   ├─Token(LeftBrace) |{|
-//@[019:00021) |   |   |   |   ├─Token(NewLine) |\r\n|
     }
-//@[008:00024) |   |   |   |   ├─ObjectPropertySyntax
-//@[008:00013) |   |   |   |   | ├─IdentifierSyntax
-//@[008:00013) |   |   |   |   | | └─Token(Identifier) |state|
-//@[013:00014) |   |   |   |   | ├─Token(Colon) |:|
-//@[015:00024) |   |   |   |   | └─StringSyntax
-//@[015:00024) |   |   |   |   |   └─Token(StringComplete) |'Enabled'|
-//@[024:00026) |   |   |   |   ├─Token(NewLine) |\r\n|
   }
-//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
-//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
 }
 
 //nameof
 var nameof1 = nameof(sqlServer)
 var nameof2 = nameof(sqlServer.location)
 var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
-//@[004:00005) |   |   |   └─Token(RightBrace) |}|
-//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
 var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
-//@[002:00003) |   |   └─Token(RightBrace) |}|
-//@[003:00005) |   ├─Token(NewLine) |\r\n|
 var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
 
 var sqlConfig = {
   westus: {}
-  server: {}
-  'my-rg': {}
-//@[000:00001) |   └─Token(RightBrace) |}|
-//@[001:00003) ├─Token(NewLine) |\n\n|
+  'server-name': {}
 }
 
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
-  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
-//@[008:00009) ├─Token(NewLine) |\n|
+  name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
   location: nameof(sqlConfig.westus)
-  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }
 
-//@[000:00031) ├─VariableDeclarationSyntax
-//@[000:00003) | ├─Token(Identifier) |var|
-//@[004:00011) | ├─IdentifierSyntax
-//@[004:00011) | | └─Token(Identifier) |nameof1|
-//@[012:00013) | ├─Token(Assignment) |=|
-//@[014:00031) | └─FunctionCallSyntax
-//@[014:00020) |   ├─IdentifierSyntax
-//@[014:00020) |   | └─Token(Identifier) |nameof|
-//@[020:00021) |   ├─Token(LeftParen) |(|
-//@[021:00030) |   ├─FunctionArgumentSyntax
-//@[021:00030) |   | └─VariableAccessSyntax
-//@[021:00030) |   |   └─IdentifierSyntax
-//@[021:00030) |   |     └─Token(Identifier) |sqlServer|
-//@[030:00031) |   └─Token(RightParen) |)|
-//@[031:00032) ├─Token(NewLine) |\n|
+//@[000:13471) ProgramSyntax
+//@[000:00001) ├─Token(NewLine) |\n|

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.tokens.bicep
@@ -1,2636 +1,540 @@
 
-//@[000:002) NewLine |\r\n|
 @sys.description('this is basicStorage')
-//@[000:001) At |@|
-//@[001:004) Identifier |sys|
-//@[004:005) Dot |.|
-//@[005:016) Identifier |description|
-//@[016:017) LeftParen |(|
-//@[017:039) StringComplete |'this is basicStorage'|
-//@[039:040) RightParen |)|
-//@[040:042) NewLine |\r\n|
 resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:021) Identifier |basicStorage|
-//@[022:068) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
-//@[069:070) Assignment |=|
-//@[071:072) LeftBrace |{|
-//@[072:074) NewLine |\r\n|
   name: 'basicblobs'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:020) StringComplete |'basicblobs'|
-//@[020:022) NewLine |\r\n|
   location: 'westus'
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:020) StringComplete |'westus'|
-//@[020:022) NewLine |\r\n|
   kind: 'BlobStorage'
-//@[002:006) Identifier |kind|
-//@[006:007) Colon |:|
-//@[008:021) StringComplete |'BlobStorage'|
-//@[021:023) NewLine |\r\n|
   sku: {
-//@[002:005) Identifier |sku|
-//@[005:006) Colon |:|
-//@[007:008) LeftBrace |{|
-//@[008:010) NewLine |\r\n|
     name: 'Standard_GRS'
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:024) StringComplete |'Standard_GRS'|
-//@[024:026) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 @sys.description('this is dnsZone')
-//@[000:001) At |@|
-//@[001:004) Identifier |sys|
-//@[004:005) Dot |.|
-//@[005:016) Identifier |description|
-//@[016:017) LeftParen |(|
-//@[017:034) StringComplete |'this is dnsZone'|
-//@[034:035) RightParen |)|
-//@[035:037) NewLine |\r\n|
 resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
-//@[000:008) Identifier |resource|
-//@[009:016) Identifier |dnsZone|
-//@[017:056) StringComplete |'Microsoft.Network/dnszones@2018-05-01'|
-//@[057:058) Assignment |=|
-//@[059:060) LeftBrace |{|
-//@[060:062) NewLine |\r\n|
   name: 'myZone'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringComplete |'myZone'|
-//@[016:018) NewLine |\r\n|
   location: 'global'
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:020) StringComplete |'global'|
-//@[020:022) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource myStorageAccount 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@[000:008) Identifier |resource|
-//@[009:025) Identifier |myStorageAccount|
-//@[026:072) StringComplete |'Microsoft.Storage/storageAccounts@2017-10-01'|
-//@[073:074) Assignment |=|
-//@[075:076) LeftBrace |{|
-//@[076:078) NewLine |\r\n|
   name: 'myencryptedone'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:024) StringComplete |'myencryptedone'|
-//@[024:026) NewLine |\r\n|
   location: 'eastus2'
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:021) StringComplete |'eastus2'|
-//@[021:023) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     supportsHttpsTrafficOnly: true
-//@[004:028) Identifier |supportsHttpsTrafficOnly|
-//@[028:029) Colon |:|
-//@[030:034) TrueKeyword |true|
-//@[034:036) NewLine |\r\n|
     accessTier: 'Hot'
-//@[004:014) Identifier |accessTier|
-//@[014:015) Colon |:|
-//@[016:021) StringComplete |'Hot'|
-//@[021:023) NewLine |\r\n|
     encryption: {
-//@[004:014) Identifier |encryption|
-//@[014:015) Colon |:|
-//@[016:017) LeftBrace |{|
-//@[017:019) NewLine |\r\n|
       keySource: 'Microsoft.Storage'
-//@[006:015) Identifier |keySource|
-//@[015:016) Colon |:|
-//@[017:036) StringComplete |'Microsoft.Storage'|
-//@[036:038) NewLine |\r\n|
       services: {
-//@[006:014) Identifier |services|
-//@[014:015) Colon |:|
-//@[016:017) LeftBrace |{|
-//@[017:019) NewLine |\r\n|
         blob: {
-//@[008:012) Identifier |blob|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
           enabled: true
-//@[010:017) Identifier |enabled|
-//@[017:018) Colon |:|
-//@[019:023) TrueKeyword |true|
-//@[023:025) NewLine |\r\n|
         }
-//@[008:009) RightBrace |}|
-//@[009:011) NewLine |\r\n|
         file: {
-//@[008:012) Identifier |file|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
           enabled: true
-//@[010:017) Identifier |enabled|
-//@[017:018) Colon |:|
-//@[019:023) TrueKeyword |true|
-//@[023:025) NewLine |\r\n|
         }
-//@[008:009) RightBrace |}|
-//@[009:011) NewLine |\r\n|
       }
-//@[006:007) RightBrace |}|
-//@[007:009) NewLine |\r\n|
     }
-//@[004:005) RightBrace |}|
-//@[005:007) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   kind: 'StorageV2'
-//@[002:006) Identifier |kind|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'StorageV2'|
-//@[019:021) NewLine |\r\n|
   sku: {
-//@[002:005) Identifier |sku|
-//@[005:006) Colon |:|
-//@[007:008) LeftBrace |{|
-//@[008:010) NewLine |\r\n|
     name: 'Standard_LRS'
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:024) StringComplete |'Standard_LRS'|
-//@[024:026) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
-//@[000:008) Identifier |resource|
-//@[009:024) Identifier |withExpressions|
-//@[025:071) StringComplete |'Microsoft.Storage/storageAccounts@2017-10-01'|
-//@[072:073) Assignment |=|
-//@[074:075) LeftBrace |{|
-//@[075:077) NewLine |\r\n|
   name: 'myencryptedone2'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:025) StringComplete |'myencryptedone2'|
-//@[025:027) NewLine |\r\n|
   location: 'eastus2'
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:021) StringComplete |'eastus2'|
-//@[021:023) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     supportsHttpsTrafficOnly: !false
-//@[004:028) Identifier |supportsHttpsTrafficOnly|
-//@[028:029) Colon |:|
-//@[030:031) Exclamation |!|
-//@[031:036) FalseKeyword |false|
-//@[036:038) NewLine |\r\n|
     accessTier: true ? 'Hot' : 'Cold'
-//@[004:014) Identifier |accessTier|
-//@[014:015) Colon |:|
-//@[016:020) TrueKeyword |true|
-//@[021:022) Question |?|
-//@[023:028) StringComplete |'Hot'|
-//@[029:030) Colon |:|
-//@[031:037) StringComplete |'Cold'|
-//@[037:039) NewLine |\r\n|
     encryption: {
-//@[004:014) Identifier |encryption|
-//@[014:015) Colon |:|
-//@[016:017) LeftBrace |{|
-//@[017:019) NewLine |\r\n|
       keySource: 'Microsoft.Storage'
-//@[006:015) Identifier |keySource|
-//@[015:016) Colon |:|
-//@[017:036) StringComplete |'Microsoft.Storage'|
-//@[036:038) NewLine |\r\n|
       services: {
-//@[006:014) Identifier |services|
-//@[014:015) Colon |:|
-//@[016:017) LeftBrace |{|
-//@[017:019) NewLine |\r\n|
         blob: {
-//@[008:012) Identifier |blob|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
           enabled: true || false
-//@[010:017) Identifier |enabled|
-//@[017:018) Colon |:|
-//@[019:023) TrueKeyword |true|
-//@[024:026) LogicalOr ||||
-//@[027:032) FalseKeyword |false|
-//@[032:034) NewLine |\r\n|
         }
-//@[008:009) RightBrace |}|
-//@[009:011) NewLine |\r\n|
         file: {
-//@[008:012) Identifier |file|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
           enabled: true
-//@[010:017) Identifier |enabled|
-//@[017:018) Colon |:|
-//@[019:023) TrueKeyword |true|
-//@[023:025) NewLine |\r\n|
         }
-//@[008:009) RightBrace |}|
-//@[009:011) NewLine |\r\n|
       }
-//@[006:007) RightBrace |}|
-//@[007:009) NewLine |\r\n|
     }
-//@[004:005) RightBrace |}|
-//@[005:007) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   kind: 'StorageV2'
-//@[002:006) Identifier |kind|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'StorageV2'|
-//@[019:021) NewLine |\r\n|
   sku: {
-//@[002:005) Identifier |sku|
-//@[005:006) Colon |:|
-//@[007:008) LeftBrace |{|
-//@[008:010) NewLine |\r\n|
     name: 'Standard_LRS'
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:024) StringComplete |'Standard_LRS'|
-//@[024:026) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   dependsOn: [
-//@[002:011) Identifier |dependsOn|
-//@[011:012) Colon |:|
-//@[013:014) LeftSquare |[|
-//@[014:016) NewLine |\r\n|
     myStorageAccount
-//@[004:020) Identifier |myStorageAccount|
-//@[020:022) NewLine |\r\n|
   ]
-//@[002:003) RightSquare |]|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 param applicationName string = 'to-do-app${uniqueString(resourceGroup().id)}'
-//@[000:005) Identifier |param|
-//@[006:021) Identifier |applicationName|
-//@[022:028) Identifier |string|
-//@[029:030) Assignment |=|
-//@[031:043) StringLeftPiece |'to-do-app${|
-//@[043:055) Identifier |uniqueString|
-//@[055:056) LeftParen |(|
-//@[056:069) Identifier |resourceGroup|
-//@[069:070) LeftParen |(|
-//@[070:071) RightParen |)|
-//@[071:072) Dot |.|
-//@[072:074) Identifier |id|
-//@[074:075) RightParen |)|
-//@[075:077) StringRightPiece |}'|
-//@[077:079) NewLine |\r\n|
 var hostingPlanName = applicationName // why not just use the param directly?
-//@[000:003) Identifier |var|
-//@[004:019) Identifier |hostingPlanName|
-//@[020:021) Assignment |=|
-//@[022:037) Identifier |applicationName|
-//@[077:081) NewLine |\r\n\r\n|
 
 param appServicePlanTier string
-//@[000:005) Identifier |param|
-//@[006:024) Identifier |appServicePlanTier|
-//@[025:031) Identifier |string|
-//@[031:033) NewLine |\r\n|
 param appServicePlanInstances int
-//@[000:005) Identifier |param|
-//@[006:029) Identifier |appServicePlanInstances|
-//@[030:033) Identifier |int|
-//@[033:037) NewLine |\r\n\r\n|
 
 var location = resourceGroup().location
-//@[000:003) Identifier |var|
-//@[004:012) Identifier |location|
-//@[013:014) Assignment |=|
-//@[015:028) Identifier |resourceGroup|
-//@[028:029) LeftParen |(|
-//@[029:030) RightParen |)|
-//@[030:031) Dot |.|
-//@[031:039) Identifier |location|
-//@[039:043) NewLine |\r\n\r\n|
 
 resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
-//@[000:008) Identifier |resource|
-//@[009:013) Identifier |farm|
-//@[014:052) StringComplete |'Microsoft.Web/serverFarms@2019-08-01'|
-//@[053:054) Assignment |=|
-//@[055:056) LeftBrace |{|
-//@[056:058) NewLine |\r\n|
   // dependsOn: resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosAccountName)
-//@[086:088) NewLine |\r\n|
   name: hostingPlanName
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:023) Identifier |hostingPlanName|
-//@[023:025) NewLine |\r\n|
   location: location
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:020) Identifier |location|
-//@[020:022) NewLine |\r\n|
   sku: {
-//@[002:005) Identifier |sku|
-//@[005:006) Colon |:|
-//@[007:008) LeftBrace |{|
-//@[008:010) NewLine |\r\n|
     name: appServicePlanTier
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:028) Identifier |appServicePlanTier|
-//@[028:030) NewLine |\r\n|
     capacity: appServicePlanInstances
-//@[004:012) Identifier |capacity|
-//@[012:013) Colon |:|
-//@[014:037) Identifier |appServicePlanInstances|
-//@[037:039) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     name: hostingPlanName // just hostingPlanName results in an error
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:025) Identifier |hostingPlanName|
-//@[069:071) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
-//@[000:003) Identifier |var|
-//@[004:022) Identifier |cosmosDbResourceId|
-//@[023:024) Assignment |=|
-//@[025:035) Identifier |resourceId|
-//@[035:036) LeftParen |(|
-//@[036:075) StringComplete |'Microsoft.DocumentDB/databaseAccounts'|
-//@[075:076) Comma |,|
-//@[076:078) NewLine |\r\n|
 // comment
-//@[010:012) NewLine |\r\n|
 cosmosDb.account)
-//@[000:008) Identifier |cosmosDb|
-//@[008:009) Dot |.|
-//@[009:016) Identifier |account|
-//@[016:017) RightParen |)|
-//@[017:019) NewLine |\r\n|
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
-//@[000:003) Identifier |var|
-//@[004:015) Identifier |cosmosDbRef|
-//@[016:017) Assignment |=|
-//@[018:027) Identifier |reference|
-//@[027:028) LeftParen |(|
-//@[028:046) Identifier |cosmosDbResourceId|
-//@[046:047) RightParen |)|
-//@[047:048) Dot |.|
-//@[048:064) Identifier |documentEndpoint|
-//@[064:068) NewLine |\r\n\r\n|
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference
-//@[094:096) NewLine |\r\n|
 // it should not be present at all in the template output as there is nowhere logical to put it
-//@[095:097) NewLine |\r\n|
 var cosmosDbEndpoint = cosmosDbRef.documentEndpoint
-//@[000:003) Identifier |var|
-//@[004:020) Identifier |cosmosDbEndpoint|
-//@[021:022) Assignment |=|
-//@[023:034) Identifier |cosmosDbRef|
-//@[034:035) Dot |.|
-//@[035:051) Identifier |documentEndpoint|
-//@[051:055) NewLine |\r\n\r\n|
 
 param webSiteName string
-//@[000:005) Identifier |param|
-//@[006:017) Identifier |webSiteName|
-//@[018:024) Identifier |string|
-//@[024:026) NewLine |\r\n|
 param cosmosDb object
-//@[000:005) Identifier |param|
-//@[006:014) Identifier |cosmosDb|
-//@[015:021) Identifier |object|
-//@[021:023) NewLine |\r\n|
 resource site 'Microsoft.Web/sites@2019-08-01' = {
-//@[000:008) Identifier |resource|
-//@[009:013) Identifier |site|
-//@[014:046) StringComplete |'Microsoft.Web/sites@2019-08-01'|
-//@[047:048) Assignment |=|
-//@[049:050) LeftBrace |{|
-//@[050:052) NewLine |\r\n|
   name: webSiteName
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:019) Identifier |webSiteName|
-//@[019:021) NewLine |\r\n|
   location: location
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:020) Identifier |location|
-//@[020:022) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     // not yet supported // serverFarmId: farm.id
-//@[049:051) NewLine |\r\n|
     siteConfig: {
-//@[004:014) Identifier |siteConfig|
-//@[014:015) Colon |:|
-//@[016:017) LeftBrace |{|
-//@[017:019) NewLine |\r\n|
       appSettings: [
-//@[006:017) Identifier |appSettings|
-//@[017:018) Colon |:|
-//@[019:020) LeftSquare |[|
-//@[020:022) NewLine |\r\n|
         {
-//@[008:009) LeftBrace |{|
-//@[009:011) NewLine |\r\n|
           name: 'CosmosDb:Account'
-//@[010:014) Identifier |name|
-//@[014:015) Colon |:|
-//@[016:034) StringComplete |'CosmosDb:Account'|
-//@[034:036) NewLine |\r\n|
           value: reference(cosmosDbResourceId).documentEndpoint
-//@[010:015) Identifier |value|
-//@[015:016) Colon |:|
-//@[017:026) Identifier |reference|
-//@[026:027) LeftParen |(|
-//@[027:045) Identifier |cosmosDbResourceId|
-//@[045:046) RightParen |)|
-//@[046:047) Dot |.|
-//@[047:063) Identifier |documentEndpoint|
-//@[063:065) NewLine |\r\n|
         }
-//@[008:009) RightBrace |}|
-//@[009:011) NewLine |\r\n|
         {
-//@[008:009) LeftBrace |{|
-//@[009:011) NewLine |\r\n|
           name: 'CosmosDb:Key'
-//@[010:014) Identifier |name|
-//@[014:015) Colon |:|
-//@[016:030) StringComplete |'CosmosDb:Key'|
-//@[030:032) NewLine |\r\n|
           value: listKeys(cosmosDbResourceId, '2020-04-01').primaryMasterKey
-//@[010:015) Identifier |value|
-//@[015:016) Colon |:|
-//@[017:025) Identifier |listKeys|
-//@[025:026) LeftParen |(|
-//@[026:044) Identifier |cosmosDbResourceId|
-//@[044:045) Comma |,|
-//@[046:058) StringComplete |'2020-04-01'|
-//@[058:059) RightParen |)|
-//@[059:060) Dot |.|
-//@[060:076) Identifier |primaryMasterKey|
-//@[076:078) NewLine |\r\n|
         }
-//@[008:009) RightBrace |}|
-//@[009:011) NewLine |\r\n|
         {
-//@[008:009) LeftBrace |{|
-//@[009:011) NewLine |\r\n|
           name: 'CosmosDb:DatabaseName'
-//@[010:014) Identifier |name|
-//@[014:015) Colon |:|
-//@[016:039) StringComplete |'CosmosDb:DatabaseName'|
-//@[039:041) NewLine |\r\n|
           value: cosmosDb.databaseName
-//@[010:015) Identifier |value|
-//@[015:016) Colon |:|
-//@[017:025) Identifier |cosmosDb|
-//@[025:026) Dot |.|
-//@[026:038) Identifier |databaseName|
-//@[038:040) NewLine |\r\n|
         }
-//@[008:009) RightBrace |}|
-//@[009:011) NewLine |\r\n|
         {
-//@[008:009) LeftBrace |{|
-//@[009:011) NewLine |\r\n|
           name: 'CosmosDb:ContainerName'
-//@[010:014) Identifier |name|
-//@[014:015) Colon |:|
-//@[016:040) StringComplete |'CosmosDb:ContainerName'|
-//@[040:042) NewLine |\r\n|
           value: cosmosDb.containerName
-//@[010:015) Identifier |value|
-//@[015:016) Colon |:|
-//@[017:025) Identifier |cosmosDb|
-//@[025:026) Dot |.|
-//@[026:039) Identifier |containerName|
-//@[039:041) NewLine |\r\n|
         }
-//@[008:009) RightBrace |}|
-//@[009:011) NewLine |\r\n|
       ]
-//@[006:007) RightSquare |]|
-//@[007:009) NewLine |\r\n|
     }
-//@[004:005) RightBrace |}|
-//@[005:007) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 var _siteApiVersion = site.apiVersion
-//@[000:003) Identifier |var|
-//@[004:019) Identifier |_siteApiVersion|
-//@[020:021) Assignment |=|
-//@[022:026) Identifier |site|
-//@[026:027) Dot |.|
-//@[027:037) Identifier |apiVersion|
-//@[037:039) NewLine |\r\n|
 var _siteType = site.type
-//@[000:003) Identifier |var|
-//@[004:013) Identifier |_siteType|
-//@[014:015) Assignment |=|
-//@[016:020) Identifier |site|
-//@[020:021) Dot |.|
-//@[021:025) Identifier |type|
-//@[025:029) NewLine |\r\n\r\n|
 
 output siteApiVersion string = site.apiVersion
-//@[000:006) Identifier |output|
-//@[007:021) Identifier |siteApiVersion|
-//@[022:028) Identifier |string|
-//@[029:030) Assignment |=|
-//@[031:035) Identifier |site|
-//@[035:036) Dot |.|
-//@[036:046) Identifier |apiVersion|
-//@[046:048) NewLine |\r\n|
 output siteType string = site.type
-//@[000:006) Identifier |output|
-//@[007:015) Identifier |siteType|
-//@[016:022) Identifier |string|
-//@[023:024) Assignment |=|
-//@[025:029) Identifier |site|
-//@[029:030) Dot |.|
-//@[030:034) Identifier |type|
-//@[034:038) NewLine |\r\n\r\n|
 
 resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
-//@[000:008) Identifier |resource|
-//@[009:015) Identifier |nested|
-//@[016:060) StringComplete |'Microsoft.Resources/deployments@2019-10-01'|
-//@[061:062) Assignment |=|
-//@[063:064) LeftBrace |{|
-//@[064:066) NewLine |\r\n|
   name: 'nestedTemplate1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:025) StringComplete |'nestedTemplate1'|
-//@[025:027) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     mode: 'Incremental'
-//@[004:008) Identifier |mode|
-//@[008:009) Colon |:|
-//@[010:023) StringComplete |'Incremental'|
-//@[023:025) NewLine |\r\n|
     template: {
-//@[004:012) Identifier |template|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
       // string key value
-//@[025:027) NewLine |\r\n|
       '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-//@[006:015) StringComplete |'$schema'|
-//@[015:016) Colon |:|
-//@[017:098) StringComplete |'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'|
-//@[098:100) NewLine |\r\n|
       contentVersion: '1.0.0.0'
-//@[006:020) Identifier |contentVersion|
-//@[020:021) Colon |:|
-//@[022:031) StringComplete |'1.0.0.0'|
-//@[031:033) NewLine |\r\n|
       resources: [
-//@[006:015) Identifier |resources|
-//@[015:016) Colon |:|
-//@[017:018) LeftSquare |[|
-//@[018:020) NewLine |\r\n|
       ]
-//@[006:007) RightSquare |]|
-//@[007:009) NewLine |\r\n|
     }
-//@[004:005) RightBrace |}|
-//@[005:007) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 // should be able to access the read only properties
-//@[052:054) NewLine |\r\n|
 resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
-//@[000:008) Identifier |resource|
-//@[009:036) Identifier |accessingReadOnlyProperties|
-//@[037:068) StringComplete |'Microsoft.Foo/foos@2019-10-01'|
-//@[069:070) Assignment |=|
-//@[071:072) LeftBrace |{|
-//@[072:074) NewLine |\r\n|
   name: 'nestedTemplate1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:025) StringComplete |'nestedTemplate1'|
-//@[025:027) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     otherId: nested.id
-//@[004:011) Identifier |otherId|
-//@[011:012) Colon |:|
-//@[013:019) Identifier |nested|
-//@[019:020) Dot |.|
-//@[020:022) Identifier |id|
-//@[022:024) NewLine |\r\n|
     otherName: nested.name
-//@[004:013) Identifier |otherName|
-//@[013:014) Colon |:|
-//@[015:021) Identifier |nested|
-//@[021:022) Dot |.|
-//@[022:026) Identifier |name|
-//@[026:028) NewLine |\r\n|
     otherVersion: nested.apiVersion
-//@[004:016) Identifier |otherVersion|
-//@[016:017) Colon |:|
-//@[018:024) Identifier |nested|
-//@[024:025) Dot |.|
-//@[025:035) Identifier |apiVersion|
-//@[035:037) NewLine |\r\n|
     otherType: nested.type
-//@[004:013) Identifier |otherType|
-//@[013:014) Colon |:|
-//@[015:021) Identifier |nested|
-//@[021:022) Dot |.|
-//@[022:026) Identifier |type|
-//@[026:030) NewLine |\r\n\r\n|
 
     otherThings: nested.properties.mode
-//@[004:015) Identifier |otherThings|
-//@[015:016) Colon |:|
-//@[017:023) Identifier |nested|
-//@[023:024) Dot |.|
-//@[024:034) Identifier |properties|
-//@[034:035) Dot |.|
-//@[035:039) Identifier |mode|
-//@[039:041) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource resourceA 'My.Rp/typeA@2020-01-01' = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |resourceA|
-//@[019:043) StringComplete |'My.Rp/typeA@2020-01-01'|
-//@[044:045) Assignment |=|
-//@[046:047) LeftBrace |{|
-//@[047:049) NewLine |\r\n|
   name: 'resourceA'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'resourceA'|
-//@[019:021) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource resourceB 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |resourceB|
-//@[019:049) StringComplete |'My.Rp/typeA/typeB@2020-01-01'|
-//@[050:051) Assignment |=|
-//@[052:053) LeftBrace |{|
-//@[053:055) NewLine |\r\n|
   name: '${resourceA.name}/myName'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:011) StringLeftPiece |'${|
-//@[011:020) Identifier |resourceA|
-//@[020:021) Dot |.|
-//@[021:025) Identifier |name|
-//@[025:034) StringRightPiece |}/myName'|
-//@[034:036) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |resourceC|
-//@[019:049) StringComplete |'My.Rp/typeA/typeB@2020-01-01'|
-//@[050:051) Assignment |=|
-//@[052:053) LeftBrace |{|
-//@[053:055) NewLine |\r\n|
   name: '${resourceA.name}/myName'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:011) StringLeftPiece |'${|
-//@[011:020) Identifier |resourceA|
-//@[020:021) Dot |.|
-//@[021:025) Identifier |name|
-//@[025:034) StringRightPiece |}/myName'|
-//@[034:036) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     aId: resourceA.id
-//@[004:007) Identifier |aId|
-//@[007:008) Colon |:|
-//@[009:018) Identifier |resourceA|
-//@[018:019) Dot |.|
-//@[019:021) Identifier |id|
-//@[021:023) NewLine |\r\n|
     aType: resourceA.type
-//@[004:009) Identifier |aType|
-//@[009:010) Colon |:|
-//@[011:020) Identifier |resourceA|
-//@[020:021) Dot |.|
-//@[021:025) Identifier |type|
-//@[025:027) NewLine |\r\n|
     aName: resourceA.name
-//@[004:009) Identifier |aName|
-//@[009:010) Colon |:|
-//@[011:020) Identifier |resourceA|
-//@[020:021) Dot |.|
-//@[021:025) Identifier |name|
-//@[025:027) NewLine |\r\n|
     aApiVersion: resourceA.apiVersion
-//@[004:015) Identifier |aApiVersion|
-//@[015:016) Colon |:|
-//@[017:026) Identifier |resourceA|
-//@[026:027) Dot |.|
-//@[027:037) Identifier |apiVersion|
-//@[037:039) NewLine |\r\n|
     bProperties: resourceB.properties
-//@[004:015) Identifier |bProperties|
-//@[015:016) Colon |:|
-//@[017:026) Identifier |resourceB|
-//@[026:027) Dot |.|
-//@[027:037) Identifier |properties|
-//@[037:039) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 var varARuntime = {
-//@[000:003) Identifier |var|
-//@[004:015) Identifier |varARuntime|
-//@[016:017) Assignment |=|
-//@[018:019) LeftBrace |{|
-//@[019:021) NewLine |\r\n|
   bId: resourceB.id
-//@[002:005) Identifier |bId|
-//@[005:006) Colon |:|
-//@[007:016) Identifier |resourceB|
-//@[016:017) Dot |.|
-//@[017:019) Identifier |id|
-//@[019:021) NewLine |\r\n|
   bType: resourceB.type
-//@[002:007) Identifier |bType|
-//@[007:008) Colon |:|
-//@[009:018) Identifier |resourceB|
-//@[018:019) Dot |.|
-//@[019:023) Identifier |type|
-//@[023:025) NewLine |\r\n|
   bName: resourceB.name
-//@[002:007) Identifier |bName|
-//@[007:008) Colon |:|
-//@[009:018) Identifier |resourceB|
-//@[018:019) Dot |.|
-//@[019:023) Identifier |name|
-//@[023:025) NewLine |\r\n|
   bApiVersion: resourceB.apiVersion
-//@[002:013) Identifier |bApiVersion|
-//@[013:014) Colon |:|
-//@[015:024) Identifier |resourceB|
-//@[024:025) Dot |.|
-//@[025:035) Identifier |apiVersion|
-//@[035:037) NewLine |\r\n|
   aKind: resourceA.kind
-//@[002:007) Identifier |aKind|
-//@[007:008) Colon |:|
-//@[009:018) Identifier |resourceA|
-//@[018:019) Dot |.|
-//@[019:023) Identifier |kind|
-//@[023:025) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 var varBRuntime = [
-//@[000:003) Identifier |var|
-//@[004:015) Identifier |varBRuntime|
-//@[016:017) Assignment |=|
-//@[018:019) LeftSquare |[|
-//@[019:021) NewLine |\r\n|
   varARuntime
-//@[002:013) Identifier |varARuntime|
-//@[013:015) NewLine |\r\n|
 ]
-//@[000:001) RightSquare |]|
-//@[001:005) NewLine |\r\n\r\n|
 
 var resourceCRef = {
-//@[000:003) Identifier |var|
-//@[004:016) Identifier |resourceCRef|
-//@[017:018) Assignment |=|
-//@[019:020) LeftBrace |{|
-//@[020:022) NewLine |\r\n|
   id: resourceC.id
-//@[002:004) Identifier |id|
-//@[004:005) Colon |:|
-//@[006:015) Identifier |resourceC|
-//@[015:016) Dot |.|
-//@[016:018) Identifier |id|
-//@[018:020) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:003) NewLine |\r\n|
 var setResourceCRef = true
-//@[000:003) Identifier |var|
-//@[004:019) Identifier |setResourceCRef|
-//@[020:021) Assignment |=|
-//@[022:026) TrueKeyword |true|
-//@[026:030) NewLine |\r\n\r\n|
 
 resource resourceD 'My.Rp/typeD@2020-01-01' = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |resourceD|
-//@[019:043) StringComplete |'My.Rp/typeD@2020-01-01'|
-//@[044:045) Assignment |=|
-//@[046:047) LeftBrace |{|
-//@[047:049) NewLine |\r\n|
   name: 'constant'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:018) StringComplete |'constant'|
-//@[018:020) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     runtime: varBRuntime
-//@[004:011) Identifier |runtime|
-//@[011:012) Colon |:|
-//@[013:024) Identifier |varBRuntime|
-//@[024:026) NewLine |\r\n|
     // repro for https://github.com/Azure/bicep/issues/316
-//@[058:060) NewLine |\r\n|
     repro316: setResourceCRef ? resourceCRef : null
-//@[004:012) Identifier |repro316|
-//@[012:013) Colon |:|
-//@[014:029) Identifier |setResourceCRef|
-//@[030:031) Question |?|
-//@[032:044) Identifier |resourceCRef|
-//@[045:046) Colon |:|
-//@[047:051) NullKeyword |null|
-//@[051:053) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 var myInterpKey = 'abc'
-//@[000:003) Identifier |var|
-//@[004:015) Identifier |myInterpKey|
-//@[016:017) Assignment |=|
-//@[018:023) StringComplete |'abc'|
-//@[023:025) NewLine |\r\n|
 resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
-//@[000:008) Identifier |resource|
-//@[009:027) Identifier |resourceWithInterp|
-//@[028:053) StringComplete |'My.Rp/interp@2020-01-01'|
-//@[054:055) Assignment |=|
-//@[056:057) LeftBrace |{|
-//@[057:059) NewLine |\r\n|
   name: 'interpTest'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:020) StringComplete |'interpTest'|
-//@[020:022) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     '${myInterpKey}': 1
-//@[004:007) StringLeftPiece |'${|
-//@[007:018) Identifier |myInterpKey|
-//@[018:020) StringRightPiece |}'|
-//@[020:021) Colon |:|
-//@[022:023) Integer |1|
-//@[023:025) NewLine |\r\n|
     'abc${myInterpKey}def': 2
-//@[004:010) StringLeftPiece |'abc${|
-//@[010:021) Identifier |myInterpKey|
-//@[021:026) StringRightPiece |}def'|
-//@[026:027) Colon |:|
-//@[028:029) Integer |2|
-//@[029:031) NewLine |\r\n|
     '${myInterpKey}abc${myInterpKey}': 3
-//@[004:007) StringLeftPiece |'${|
-//@[007:018) Identifier |myInterpKey|
-//@[018:024) StringMiddlePiece |}abc${|
-//@[024:035) Identifier |myInterpKey|
-//@[035:037) StringRightPiece |}'|
-//@[037:038) Colon |:|
-//@[039:040) Integer |3|
-//@[040:042) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
-//@[000:008) Identifier |resource|
-//@[009:029) Identifier |resourceWithEscaping|
-//@[030:061) StringComplete |'My.Rp/mockResource@2020-01-01'|
-//@[062:063) Assignment |=|
-//@[064:065) LeftBrace |{|
-//@[065:067) NewLine |\r\n|
   name: 'test'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:014) StringComplete |'test'|
-//@[014:016) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     // both key and value should be escaped in template output
-//@[062:064) NewLine |\r\n|
     '[resourceGroup().location]': '[resourceGroup().location]'
-//@[004:032) StringComplete |'[resourceGroup().location]'|
-//@[032:033) Colon |:|
-//@[034:062) StringComplete |'[resourceGroup().location]'|
-//@[062:064) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 param shouldDeployVm bool = true
-//@[000:005) Identifier |param|
-//@[006:020) Identifier |shouldDeployVm|
-//@[021:025) Identifier |bool|
-//@[026:027) Assignment |=|
-//@[028:032) TrueKeyword |true|
-//@[032:036) NewLine |\r\n\r\n|
 
 @sys.description('this is vmWithCondition')
-//@[000:001) At |@|
-//@[001:004) Identifier |sys|
-//@[004:005) Dot |.|
-//@[005:016) Identifier |description|
-//@[016:017) LeftParen |(|
-//@[017:042) StringComplete |'this is vmWithCondition'|
-//@[042:043) RightParen |)|
-//@[043:045) NewLine |\r\n|
 resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (shouldDeployVm) {
-//@[000:008) Identifier |resource|
-//@[009:024) Identifier |vmWithCondition|
-//@[025:071) StringComplete |'Microsoft.Compute/virtualMachines@2020-06-01'|
-//@[072:073) Assignment |=|
-//@[074:076) Identifier |if|
-//@[077:078) LeftParen |(|
-//@[078:092) Identifier |shouldDeployVm|
-//@[092:093) RightParen |)|
-//@[094:095) LeftBrace |{|
-//@[095:097) NewLine |\r\n|
   name: 'vmName'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringComplete |'vmName'|
-//@[016:018) NewLine |\r\n|
   location: 'westus'
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:020) StringComplete |'westus'|
-//@[020:022) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     osProfile: {
-//@[004:013) Identifier |osProfile|
-//@[013:014) Colon |:|
-//@[015:016) LeftBrace |{|
-//@[016:018) NewLine |\r\n|
       windowsConfiguration: {
-//@[006:026) Identifier |windowsConfiguration|
-//@[026:027) Colon |:|
-//@[028:029) LeftBrace |{|
-//@[029:031) NewLine |\r\n|
         enableAutomaticUpdates: true
-//@[008:030) Identifier |enableAutomaticUpdates|
-//@[030:031) Colon |:|
-//@[032:036) TrueKeyword |true|
-//@[036:038) NewLine |\r\n|
       }
-//@[006:007) RightBrace |}|
-//@[007:009) NewLine |\r\n|
     }
-//@[004:005) RightBrace |}|
-//@[005:007) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 @sys.description('this is another vmWithCondition')
-//@[000:001) At |@|
-//@[001:004) Identifier |sys|
-//@[004:005) Dot |.|
-//@[005:016) Identifier |description|
-//@[016:017) LeftParen |(|
-//@[017:050) StringComplete |'this is another vmWithCondition'|
-//@[050:051) RightParen |)|
-//@[051:053) NewLine |\r\n|
 resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
-//@[000:008) Identifier |resource|
-//@[009:025) Identifier |vmWithCondition2|
-//@[026:072) StringComplete |'Microsoft.Compute/virtualMachines@2020-06-01'|
-//@[073:074) Assignment |=|
-//@[074:076) NewLine |\r\n|
                     if (shouldDeployVm) {
-//@[020:022) Identifier |if|
-//@[023:024) LeftParen |(|
-//@[024:038) Identifier |shouldDeployVm|
-//@[038:039) RightParen |)|
-//@[040:041) LeftBrace |{|
-//@[041:043) NewLine |\r\n|
   name: 'vmName2'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:017) StringComplete |'vmName2'|
-//@[017:019) NewLine |\r\n|
   location: 'westus'
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:020) StringComplete |'westus'|
-//@[020:022) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     osProfile: {
-//@[004:013) Identifier |osProfile|
-//@[013:014) Colon |:|
-//@[015:016) LeftBrace |{|
-//@[016:018) NewLine |\r\n|
       windowsConfiguration: {
-//@[006:026) Identifier |windowsConfiguration|
-//@[026:027) Colon |:|
-//@[028:029) LeftBrace |{|
-//@[029:031) NewLine |\r\n|
         enableAutomaticUpdates: true
-//@[008:030) Identifier |enableAutomaticUpdates|
-//@[030:031) Colon |:|
-//@[032:036) TrueKeyword |true|
-//@[036:038) NewLine |\r\n|
       }
-//@[006:007) RightBrace |}|
-//@[007:009) NewLine |\r\n|
     }
-//@[004:005) RightBrace |}|
-//@[005:007) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource extension1 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:008) Identifier |resource|
-//@[009:019) Identifier |extension1|
-//@[020:056) StringComplete |'My.Rp/extensionResource@2020-12-01'|
-//@[057:058) Assignment |=|
-//@[059:060) LeftBrace |{|
-//@[060:062) NewLine |\r\n|
   name: 'extension'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'extension'|
-//@[019:021) NewLine |\r\n|
   scope: vmWithCondition
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:024) Identifier |vmWithCondition|
-//@[024:026) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource extension2 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:008) Identifier |resource|
-//@[009:019) Identifier |extension2|
-//@[020:056) StringComplete |'My.Rp/extensionResource@2020-12-01'|
-//@[057:058) Assignment |=|
-//@[059:060) LeftBrace |{|
-//@[060:062) NewLine |\r\n|
   name: 'extension'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'extension'|
-//@[019:021) NewLine |\r\n|
   scope: extension1
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:019) Identifier |extension1|
-//@[019:021) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
-//@[000:008) Identifier |resource|
-//@[009:030) Identifier |extensionDependencies|
-//@[031:062) StringComplete |'My.Rp/mockResource@2020-01-01'|
-//@[063:064) Assignment |=|
-//@[065:066) LeftBrace |{|
-//@[066:068) NewLine |\r\n|
   name: 'extensionDependencies'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:031) StringComplete |'extensionDependencies'|
-//@[031:033) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     res1: vmWithCondition.id
-//@[004:008) Identifier |res1|
-//@[008:009) Colon |:|
-//@[010:025) Identifier |vmWithCondition|
-//@[025:026) Dot |.|
-//@[026:028) Identifier |id|
-//@[028:030) NewLine |\r\n|
     res1runtime: vmWithCondition.properties.something
-//@[004:015) Identifier |res1runtime|
-//@[015:016) Colon |:|
-//@[017:032) Identifier |vmWithCondition|
-//@[032:033) Dot |.|
-//@[033:043) Identifier |properties|
-//@[043:044) Dot |.|
-//@[044:053) Identifier |something|
-//@[053:055) NewLine |\r\n|
     res2: extension1.id
-//@[004:008) Identifier |res2|
-//@[008:009) Colon |:|
-//@[010:020) Identifier |extension1|
-//@[020:021) Dot |.|
-//@[021:023) Identifier |id|
-//@[023:025) NewLine |\r\n|
     res2runtime: extension1.properties.something
-//@[004:015) Identifier |res2runtime|
-//@[015:016) Colon |:|
-//@[017:027) Identifier |extension1|
-//@[027:028) Dot |.|
-//@[028:038) Identifier |properties|
-//@[038:039) Dot |.|
-//@[039:048) Identifier |something|
-//@[048:050) NewLine |\r\n|
     res3: extension2.id
-//@[004:008) Identifier |res3|
-//@[008:009) Colon |:|
-//@[010:020) Identifier |extension2|
-//@[020:021) Dot |.|
-//@[021:023) Identifier |id|
-//@[023:025) NewLine |\r\n|
     res3runtime: extension2.properties.something
-//@[004:015) Identifier |res3runtime|
-//@[015:016) Colon |:|
-//@[017:027) Identifier |extension2|
-//@[027:028) Dot |.|
-//@[028:038) Identifier |properties|
-//@[038:039) Dot |.|
-//@[039:048) Identifier |something|
-//@[048:050) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 @sys.description('this is existing1')
-//@[000:001) At |@|
-//@[001:004) Identifier |sys|
-//@[004:005) Dot |.|
-//@[005:016) Identifier |description|
-//@[016:017) LeftParen |(|
-//@[017:036) StringComplete |'this is existing1'|
-//@[036:037) RightParen |)|
-//@[037:039) NewLine |\r\n|
 resource existing1 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |existing1|
-//@[019:065) StringComplete |'Mock.Rp/existingExtensionResource@2020-01-01'|
-//@[066:074) Identifier |existing|
-//@[075:076) Assignment |=|
-//@[077:078) LeftBrace |{|
-//@[078:080) NewLine |\r\n|
   name: 'existing1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'existing1'|
-//@[019:021) NewLine |\r\n|
   scope: extension1
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:019) Identifier |extension1|
-//@[019:021) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource existing2 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |existing2|
-//@[019:065) StringComplete |'Mock.Rp/existingExtensionResource@2020-01-01'|
-//@[066:074) Identifier |existing|
-//@[075:076) Assignment |=|
-//@[077:078) LeftBrace |{|
-//@[078:080) NewLine |\r\n|
   name: 'existing2'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'existing2'|
-//@[019:021) NewLine |\r\n|
   scope: existing1
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:018) Identifier |existing1|
-//@[018:020) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource extension3 'My.Rp/extensionResource@2020-12-01' = {
-//@[000:008) Identifier |resource|
-//@[009:019) Identifier |extension3|
-//@[020:056) StringComplete |'My.Rp/extensionResource@2020-12-01'|
-//@[057:058) Assignment |=|
-//@[059:060) LeftBrace |{|
-//@[060:062) NewLine |\r\n|
   name: 'extension3'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:020) StringComplete |'extension3'|
-//@[020:022) NewLine |\r\n|
   scope: existing1
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:018) Identifier |existing1|
-//@[018:020) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 /*
   valid loop cases
-*/ 
-//@[003:005) NewLine |\r\n|
+*/
 var storageAccounts = [
-//@[000:003) Identifier |var|
-//@[004:019) Identifier |storageAccounts|
-//@[020:021) Assignment |=|
-//@[022:023) LeftSquare |[|
-//@[023:025) NewLine |\r\n|
   {
-//@[002:003) LeftBrace |{|
-//@[003:005) NewLine |\r\n|
     name: 'one'
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:015) StringComplete |'one'|
-//@[015:017) NewLine |\r\n|
     location: 'eastus2'
-//@[004:012) Identifier |location|
-//@[012:013) Colon |:|
-//@[014:023) StringComplete |'eastus2'|
-//@[023:025) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   {
-//@[002:003) LeftBrace |{|
-//@[003:005) NewLine |\r\n|
     name: 'two'
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:015) StringComplete |'two'|
-//@[015:017) NewLine |\r\n|
     location: 'westus'
-//@[004:012) Identifier |location|
-//@[012:013) Colon |:|
-//@[014:022) StringComplete |'westus'|
-//@[022:024) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 ]
-//@[000:001) RightSquare |]|
-//@[001:005) NewLine |\r\n\r\n|
 
 // just a storage account loop
-//@[030:032) NewLine |\r\n|
 @sys.description('this is just a storage account loop')
-//@[000:001) At |@|
-//@[001:004) Identifier |sys|
-//@[004:005) Dot |.|
-//@[005:016) Identifier |description|
-//@[016:017) LeftParen |(|
-//@[017:054) StringComplete |'this is just a storage account loop'|
-//@[054:055) RightParen |)|
-//@[055:057) NewLine |\r\n|
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
-//@[000:008) Identifier |resource|
-//@[009:025) Identifier |storageResources|
-//@[026:072) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
-//@[073:074) Assignment |=|
-//@[075:076) LeftSquare |[|
-//@[076:079) Identifier |for|
-//@[080:087) Identifier |account|
-//@[088:090) Identifier |in|
-//@[091:106) Identifier |storageAccounts|
-//@[106:107) Colon |:|
-//@[108:109) LeftBrace |{|
-//@[109:111) NewLine |\r\n|
   name: account.name
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:015) Identifier |account|
-//@[015:016) Dot |.|
-//@[016:020) Identifier |name|
-//@[020:022) NewLine |\r\n|
   location: account.location
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:019) Identifier |account|
-//@[019:020) Dot |.|
-//@[020:028) Identifier |location|
-//@[028:030) NewLine |\r\n|
   sku: {
-//@[002:005) Identifier |sku|
-//@[005:006) Colon |:|
-//@[007:008) LeftBrace |{|
-//@[008:010) NewLine |\r\n|
     name: 'Standard_LRS'
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:024) StringComplete |'Standard_LRS'|
-//@[024:026) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   kind: 'StorageV2'
-//@[002:006) Identifier |kind|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'StorageV2'|
-//@[019:021) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 // storage account loop with index
-//@[034:036) NewLine |\r\n|
 @sys.description('this is just a storage account loop with index')
-//@[000:001) At |@|
-//@[001:004) Identifier |sys|
-//@[004:005) Dot |.|
-//@[005:016) Identifier |description|
-//@[016:017) LeftParen |(|
-//@[017:065) StringComplete |'this is just a storage account loop with index'|
-//@[065:066) RightParen |)|
-//@[066:068) NewLine |\r\n|
 resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, i) in storageAccounts: {
-//@[000:008) Identifier |resource|
-//@[009:034) Identifier |storageResourcesWithIndex|
-//@[035:081) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
-//@[082:083) Assignment |=|
-//@[084:085) LeftSquare |[|
-//@[085:088) Identifier |for|
-//@[089:090) LeftParen |(|
-//@[090:097) Identifier |account|
-//@[097:098) Comma |,|
-//@[099:100) Identifier |i|
-//@[100:101) RightParen |)|
-//@[102:104) Identifier |in|
-//@[105:120) Identifier |storageAccounts|
-//@[120:121) Colon |:|
-//@[122:123) LeftBrace |{|
-//@[123:125) NewLine |\r\n|
   name: '${account.name}${i}'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:011) StringLeftPiece |'${|
-//@[011:018) Identifier |account|
-//@[018:019) Dot |.|
-//@[019:023) Identifier |name|
-//@[023:026) StringMiddlePiece |}${|
-//@[026:027) Identifier |i|
-//@[027:029) StringRightPiece |}'|
-//@[029:031) NewLine |\r\n|
   location: account.location
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:019) Identifier |account|
-//@[019:020) Dot |.|
-//@[020:028) Identifier |location|
-//@[028:030) NewLine |\r\n|
   sku: {
-//@[002:005) Identifier |sku|
-//@[005:006) Colon |:|
-//@[007:008) LeftBrace |{|
-//@[008:010) NewLine |\r\n|
     name: 'Standard_LRS'
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:024) StringComplete |'Standard_LRS'|
-//@[024:026) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   kind: 'StorageV2'
-//@[002:006) Identifier |kind|
-//@[006:007) Colon |:|
-//@[008:019) StringComplete |'StorageV2'|
-//@[019:021) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 // basic nested loop
-//@[020:022) NewLine |\r\n|
 @sys.description('this is just a basic nested loop')
-//@[000:001) At |@|
-//@[001:004) Identifier |sys|
-//@[004:005) Dot |.|
-//@[005:016) Identifier |description|
-//@[016:017) LeftParen |(|
-//@[017:051) StringComplete |'this is just a basic nested loop'|
-//@[051:052) RightParen |)|
-//@[052:054) NewLine |\r\n|
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[000:008) Identifier |resource|
-//@[009:013) Identifier |vnet|
-//@[014:060) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[061:062) Assignment |=|
-//@[063:064) LeftSquare |[|
-//@[064:067) Identifier |for|
-//@[068:069) Identifier |i|
-//@[070:072) Identifier |in|
-//@[073:078) Identifier |range|
-//@[078:079) LeftParen |(|
-//@[079:080) Integer |0|
-//@[080:081) Comma |,|
-//@[082:083) Integer |3|
-//@[083:084) RightParen |)|
-//@[084:085) Colon |:|
-//@[086:087) LeftBrace |{|
-//@[087:089) NewLine |\r\n|
   name: 'vnet-${i}'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringLeftPiece |'vnet-${|
-//@[016:017) Identifier |i|
-//@[017:019) StringRightPiece |}'|
-//@[019:021) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     subnets: [for j in range(0, 4): {
-//@[004:011) Identifier |subnets|
-//@[011:012) Colon |:|
-//@[013:014) LeftSquare |[|
-//@[014:017) Identifier |for|
-//@[018:019) Identifier |j|
-//@[020:022) Identifier |in|
-//@[023:028) Identifier |range|
-//@[028:029) LeftParen |(|
-//@[029:030) Integer |0|
-//@[030:031) Comma |,|
-//@[032:033) Integer |4|
-//@[033:034) RightParen |)|
-//@[034:035) Colon |:|
-//@[036:037) LeftBrace |{|
-//@[037:039) NewLine |\r\n|
       // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
-//@[062:064) NewLine |\r\n|
-     
-//@[005:007) NewLine |\r\n|
+
       // #completionTest(6) -> subnetIdAndPropertiesNoColon
-//@[059:061) NewLine |\r\n|
       name: 'subnet-${i}-${j}'
-//@[006:010) Identifier |name|
-//@[010:011) Colon |:|
-//@[012:022) StringLeftPiece |'subnet-${|
-//@[022:023) Identifier |i|
-//@[023:027) StringMiddlePiece |}-${|
-//@[027:028) Identifier |j|
-//@[028:030) StringRightPiece |}'|
-//@[030:032) NewLine |\r\n|
     }]
-//@[004:005) RightBrace |}|
-//@[005:006) RightSquare |]|
-//@[006:008) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 // duplicate identifiers within the loop are allowed
-//@[052:054) NewLine |\r\n|
 resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[000:008) Identifier |resource|
-//@[009:039) Identifier |duplicateIdentifiersWithinLoop|
-//@[040:086) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[087:088) Assignment |=|
-//@[089:090) LeftSquare |[|
-//@[090:093) Identifier |for|
-//@[094:095) Identifier |i|
-//@[096:098) Identifier |in|
-//@[099:104) Identifier |range|
-//@[104:105) LeftParen |(|
-//@[105:106) Integer |0|
-//@[106:107) Comma |,|
-//@[108:109) Integer |3|
-//@[109:110) RightParen |)|
-//@[110:111) Colon |:|
-//@[112:113) LeftBrace |{|
-//@[113:115) NewLine |\r\n|
   name: 'vnet-${i}'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringLeftPiece |'vnet-${|
-//@[016:017) Identifier |i|
-//@[017:019) StringRightPiece |}'|
-//@[019:021) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     subnets: [for i in range(0, 4): {
-//@[004:011) Identifier |subnets|
-//@[011:012) Colon |:|
-//@[013:014) LeftSquare |[|
-//@[014:017) Identifier |for|
-//@[018:019) Identifier |i|
-//@[020:022) Identifier |in|
-//@[023:028) Identifier |range|
-//@[028:029) LeftParen |(|
-//@[029:030) Integer |0|
-//@[030:031) Comma |,|
-//@[032:033) Integer |4|
-//@[033:034) RightParen |)|
-//@[034:035) Colon |:|
-//@[036:037) LeftBrace |{|
-//@[037:039) NewLine |\r\n|
       name: 'subnet-${i}-${i}'
-//@[006:010) Identifier |name|
-//@[010:011) Colon |:|
-//@[012:022) StringLeftPiece |'subnet-${|
-//@[022:023) Identifier |i|
-//@[023:027) StringMiddlePiece |}-${|
-//@[027:028) Identifier |i|
-//@[028:030) StringRightPiece |}'|
-//@[030:032) NewLine |\r\n|
     }]
-//@[004:005) RightBrace |}|
-//@[005:006) RightSquare |]|
-//@[006:008) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 // duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
-//@[100:102) NewLine |\r\n|
 var canHaveDuplicatesAcrossScopes = 'hello'
-//@[000:003) Identifier |var|
-//@[004:033) Identifier |canHaveDuplicatesAcrossScopes|
-//@[034:035) Assignment |=|
-//@[036:043) StringComplete |'hello'|
-//@[043:045) NewLine |\r\n|
 resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
-//@[000:008) Identifier |resource|
-//@[009:036) Identifier |duplicateInGlobalAndOneLoop|
-//@[037:083) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[084:085) Assignment |=|
-//@[086:087) LeftSquare |[|
-//@[087:090) Identifier |for|
-//@[091:120) Identifier |canHaveDuplicatesAcrossScopes|
-//@[121:123) Identifier |in|
-//@[124:129) Identifier |range|
-//@[129:130) LeftParen |(|
-//@[130:131) Integer |0|
-//@[131:132) Comma |,|
-//@[133:134) Integer |3|
-//@[134:135) RightParen |)|
-//@[135:136) Colon |:|
-//@[137:138) LeftBrace |{|
-//@[138:140) NewLine |\r\n|
   name: 'vnet-${canHaveDuplicatesAcrossScopes}'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringLeftPiece |'vnet-${|
-//@[016:045) Identifier |canHaveDuplicatesAcrossScopes|
-//@[045:047) StringRightPiece |}'|
-//@[047:049) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     subnets: [for i in range(0, 4): {
-//@[004:011) Identifier |subnets|
-//@[011:012) Colon |:|
-//@[013:014) LeftSquare |[|
-//@[014:017) Identifier |for|
-//@[018:019) Identifier |i|
-//@[020:022) Identifier |in|
-//@[023:028) Identifier |range|
-//@[028:029) LeftParen |(|
-//@[029:030) Integer |0|
-//@[030:031) Comma |,|
-//@[032:033) Integer |4|
-//@[033:034) RightParen |)|
-//@[034:035) Colon |:|
-//@[036:037) LeftBrace |{|
-//@[037:039) NewLine |\r\n|
       name: 'subnet-${i}-${i}'
-//@[006:010) Identifier |name|
-//@[010:011) Colon |:|
-//@[012:022) StringLeftPiece |'subnet-${|
-//@[022:023) Identifier |i|
-//@[023:027) StringMiddlePiece |}-${|
-//@[027:028) Identifier |i|
-//@[028:030) StringRightPiece |}'|
-//@[030:032) NewLine |\r\n|
     }]
-//@[004:005) RightBrace |}|
-//@[005:006) RightSquare |]|
-//@[006:008) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 // duplicate in global and multiple loop scopes are allowed (inner hides the outer)
-//@[083:085) NewLine |\r\n|
 var duplicatesEverywhere = 'hello'
-//@[000:003) Identifier |var|
-//@[004:024) Identifier |duplicatesEverywhere|
-//@[025:026) Assignment |=|
-//@[027:034) StringComplete |'hello'|
-//@[034:036) NewLine |\r\n|
 resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
-//@[000:008) Identifier |resource|
-//@[009:037) Identifier |duplicateInGlobalAndTwoLoops|
-//@[038:084) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[085:086) Assignment |=|
-//@[087:088) LeftSquare |[|
-//@[088:091) Identifier |for|
-//@[092:112) Identifier |duplicatesEverywhere|
-//@[113:115) Identifier |in|
-//@[116:121) Identifier |range|
-//@[121:122) LeftParen |(|
-//@[122:123) Integer |0|
-//@[123:124) Comma |,|
-//@[125:126) Integer |3|
-//@[126:127) RightParen |)|
-//@[127:128) Colon |:|
-//@[129:130) LeftBrace |{|
-//@[130:132) NewLine |\r\n|
   name: 'vnet-${duplicatesEverywhere}'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringLeftPiece |'vnet-${|
-//@[016:036) Identifier |duplicatesEverywhere|
-//@[036:038) StringRightPiece |}'|
-//@[038:040) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     subnets: [for duplicatesEverywhere in range(0, 4): {
-//@[004:011) Identifier |subnets|
-//@[011:012) Colon |:|
-//@[013:014) LeftSquare |[|
-//@[014:017) Identifier |for|
-//@[018:038) Identifier |duplicatesEverywhere|
-//@[039:041) Identifier |in|
-//@[042:047) Identifier |range|
-//@[047:048) LeftParen |(|
-//@[048:049) Integer |0|
-//@[049:050) Comma |,|
-//@[051:052) Integer |4|
-//@[052:053) RightParen |)|
-//@[053:054) Colon |:|
-//@[055:056) LeftBrace |{|
-//@[056:058) NewLine |\r\n|
       name: 'subnet-${duplicatesEverywhere}'
-//@[006:010) Identifier |name|
-//@[010:011) Colon |:|
-//@[012:022) StringLeftPiece |'subnet-${|
-//@[022:042) Identifier |duplicatesEverywhere|
-//@[042:044) StringRightPiece |}'|
-//@[044:046) NewLine |\r\n|
     }]
-//@[004:005) RightBrace |}|
-//@[005:006) RightSquare |]|
-//@[006:008) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 /*
   Scope values created via array access on a resource collection
 */
-//@[002:004) NewLine |\r\n|
 resource dnsZones 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in range(0,4): {
-//@[000:008) Identifier |resource|
-//@[009:017) Identifier |dnsZones|
-//@[018:057) StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
-//@[058:059) Assignment |=|
-//@[060:061) LeftSquare |[|
-//@[061:064) Identifier |for|
-//@[065:069) Identifier |zone|
-//@[070:072) Identifier |in|
-//@[073:078) Identifier |range|
-//@[078:079) LeftParen |(|
-//@[079:080) Integer |0|
-//@[080:081) Comma |,|
-//@[081:082) Integer |4|
-//@[082:083) RightParen |)|
-//@[083:084) Colon |:|
-//@[085:086) LeftBrace |{|
-//@[086:088) NewLine |\r\n|
   name: 'zone${zone}'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:015) StringLeftPiece |'zone${|
-//@[015:019) Identifier |zone|
-//@[019:021) StringRightPiece |}'|
-//@[021:023) NewLine |\r\n|
   location: 'global'
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:020) StringComplete |'global'|
-//@[020:022) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 resource locksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for lock in range(0,2): {
-//@[000:008) Identifier |resource|
-//@[009:021) Identifier |locksOnZones|
-//@[022:064) StringComplete |'Microsoft.Authorization/locks@2016-09-01'|
-//@[065:066) Assignment |=|
-//@[067:068) LeftSquare |[|
-//@[068:071) Identifier |for|
-//@[072:076) Identifier |lock|
-//@[077:079) Identifier |in|
-//@[080:085) Identifier |range|
-//@[085:086) LeftParen |(|
-//@[086:087) Integer |0|
-//@[087:088) Comma |,|
-//@[088:089) Integer |2|
-//@[089:090) RightParen |)|
-//@[090:091) Colon |:|
-//@[092:093) LeftBrace |{|
-//@[093:095) NewLine |\r\n|
   name: 'lock${lock}'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:015) StringLeftPiece |'lock${|
-//@[015:019) Identifier |lock|
-//@[019:021) StringRightPiece |}'|
-//@[021:023) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     level: 'CanNotDelete'
-//@[004:009) Identifier |level|
-//@[009:010) Colon |:|
-//@[011:025) StringComplete |'CanNotDelete'|
-//@[025:027) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   scope: dnsZones[lock]
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:017) Identifier |dnsZones|
-//@[017:018) LeftSquare |[|
-//@[018:022) Identifier |lock|
-//@[022:023) RightSquare |]|
-//@[023:025) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 resource moreLocksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for (lock, i) in range(0,3): {
-//@[000:008) Identifier |resource|
-//@[009:025) Identifier |moreLocksOnZones|
-//@[026:068) StringComplete |'Microsoft.Authorization/locks@2016-09-01'|
-//@[069:070) Assignment |=|
-//@[071:072) LeftSquare |[|
-//@[072:075) Identifier |for|
-//@[076:077) LeftParen |(|
-//@[077:081) Identifier |lock|
-//@[081:082) Comma |,|
-//@[083:084) Identifier |i|
-//@[084:085) RightParen |)|
-//@[086:088) Identifier |in|
-//@[089:094) Identifier |range|
-//@[094:095) LeftParen |(|
-//@[095:096) Integer |0|
-//@[096:097) Comma |,|
-//@[097:098) Integer |3|
-//@[098:099) RightParen |)|
-//@[099:100) Colon |:|
-//@[101:102) LeftBrace |{|
-//@[102:104) NewLine |\r\n|
   name: 'another${i}'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:018) StringLeftPiece |'another${|
-//@[018:019) Identifier |i|
-//@[019:021) StringRightPiece |}'|
-//@[021:023) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     level: 'ReadOnly'
-//@[004:009) Identifier |level|
-//@[009:010) Colon |:|
-//@[011:021) StringComplete |'ReadOnly'|
-//@[021:023) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   scope: dnsZones[i]
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:017) Identifier |dnsZones|
-//@[017:018) LeftSquare |[|
-//@[018:019) Identifier |i|
-//@[019:020) RightSquare |]|
-//@[020:022) NewLine |\r\n|
 }]
-//@[000:001) RightBrace |}|
-//@[001:002) RightSquare |]|
-//@[002:006) NewLine |\r\n\r\n|
 
 resource singleLockOnFirstZone 'Microsoft.Authorization/locks@2016-09-01' = {
-//@[000:008) Identifier |resource|
-//@[009:030) Identifier |singleLockOnFirstZone|
-//@[031:073) StringComplete |'Microsoft.Authorization/locks@2016-09-01'|
-//@[074:075) Assignment |=|
-//@[076:077) LeftBrace |{|
-//@[077:079) NewLine |\r\n|
   name: 'single-lock'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:021) StringComplete |'single-lock'|
-//@[021:023) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     level: 'ReadOnly'
-//@[004:009) Identifier |level|
-//@[009:010) Colon |:|
-//@[011:021) StringComplete |'ReadOnly'|
-//@[021:023) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
   scope: dnsZones[0]
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:017) Identifier |dnsZones|
-//@[017:018) LeftSquare |[|
-//@[018:019) Integer |0|
-//@[019:020) RightSquare |]|
-//@[020:022) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:007) NewLine |\r\n\r\n\r\n|
 
 
 resource p1_vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:016) Identifier |p1_vnet|
-//@[017:063) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[064:065) Assignment |=|
-//@[066:067) LeftBrace |{|
-//@[067:069) NewLine |\r\n|
   location: resourceGroup().location
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:025) Identifier |resourceGroup|
-//@[025:026) LeftParen |(|
-//@[026:027) RightParen |)|
-//@[027:028) Dot |.|
-//@[028:036) Identifier |location|
-//@[036:038) NewLine |\r\n|
   name: 'myVnet'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringComplete |'myVnet'|
-//@[016:018) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     addressSpace: {
-//@[004:016) Identifier |addressSpace|
-//@[016:017) Colon |:|
-//@[018:019) LeftBrace |{|
-//@[019:021) NewLine |\r\n|
       addressPrefixes: [
-//@[006:021) Identifier |addressPrefixes|
-//@[021:022) Colon |:|
-//@[023:024) LeftSquare |[|
-//@[024:026) NewLine |\r\n|
         '10.0.0.0/20'
-//@[008:021) StringComplete |'10.0.0.0/20'|
-//@[021:023) NewLine |\r\n|
       ]
-//@[006:007) RightSquare |]|
-//@[007:009) NewLine |\r\n|
     }
-//@[004:005) RightBrace |}|
-//@[005:007) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource p1_subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:019) Identifier |p1_subnet1|
-//@[020:074) StringComplete |'Microsoft.Network/virtualNetworks/subnets@2020-06-01'|
-//@[075:076) Assignment |=|
-//@[077:078) LeftBrace |{|
-//@[078:080) NewLine |\r\n|
   parent: p1_vnet
-//@[002:008) Identifier |parent|
-//@[008:009) Colon |:|
-//@[010:017) Identifier |p1_vnet|
-//@[017:019) NewLine |\r\n|
   name: 'subnet1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:017) StringComplete |'subnet1'|
-//@[017:019) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     addressPrefix: '10.0.0.0/24'
-//@[004:017) Identifier |addressPrefix|
-//@[017:018) Colon |:|
-//@[019:032) StringComplete |'10.0.0.0/24'|
-//@[032:034) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource p1_subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:019) Identifier |p1_subnet2|
-//@[020:074) StringComplete |'Microsoft.Network/virtualNetworks/subnets@2020-06-01'|
-//@[075:076) Assignment |=|
-//@[077:078) LeftBrace |{|
-//@[078:080) NewLine |\r\n|
   parent: p1_vnet
-//@[002:008) Identifier |parent|
-//@[008:009) Colon |:|
-//@[010:017) Identifier |p1_vnet|
-//@[017:019) NewLine |\r\n|
   name: 'subnet2'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:017) StringComplete |'subnet2'|
-//@[017:019) NewLine |\r\n|
   properties: {
-//@[002:012) Identifier |properties|
-//@[012:013) Colon |:|
-//@[014:015) LeftBrace |{|
-//@[015:017) NewLine |\r\n|
     addressPrefix: '10.0.1.0/24'
-//@[004:017) Identifier |addressPrefix|
-//@[017:018) Colon |:|
-//@[019:032) StringComplete |'10.0.1.0/24'|
-//@[032:034) NewLine |\r\n|
   }
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 output p1_subnet1prefix string = p1_subnet1.properties.addressPrefix
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p1_subnet1prefix|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:043) Identifier |p1_subnet1|
-//@[043:044) Dot |.|
-//@[044:054) Identifier |properties|
-//@[054:055) Dot |.|
-//@[055:068) Identifier |addressPrefix|
-//@[068:070) NewLine |\r\n|
 output p1_subnet1name string = p1_subnet1.name
-//@[000:006) Identifier |output|
-//@[007:021) Identifier |p1_subnet1name|
-//@[022:028) Identifier |string|
-//@[029:030) Assignment |=|
-//@[031:041) Identifier |p1_subnet1|
-//@[041:042) Dot |.|
-//@[042:046) Identifier |name|
-//@[046:048) NewLine |\r\n|
 output p1_subnet1type string = p1_subnet1.type
-//@[000:006) Identifier |output|
-//@[007:021) Identifier |p1_subnet1type|
-//@[022:028) Identifier |string|
-//@[029:030) Assignment |=|
-//@[031:041) Identifier |p1_subnet1|
-//@[041:042) Dot |.|
-//@[042:046) Identifier |type|
-//@[046:048) NewLine |\r\n|
 output p1_subnet1id string = p1_subnet1.id
-//@[000:006) Identifier |output|
-//@[007:019) Identifier |p1_subnet1id|
-//@[020:026) Identifier |string|
-//@[027:028) Assignment |=|
-//@[029:039) Identifier |p1_subnet1|
-//@[039:040) Dot |.|
-//@[040:042) Identifier |id|
-//@[042:046) NewLine |\r\n\r\n|
 
 // parent property with extension resource
-//@[042:044) NewLine |\r\n|
 resource p2_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:016) Identifier |p2_res1|
-//@[017:053) StringComplete |'Microsoft.Rp1/resource1@2020-06-01'|
-//@[054:055) Assignment |=|
-//@[056:057) LeftBrace |{|
-//@[057:059) NewLine |\r\n|
   name: 'res1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:014) StringComplete |'res1'|
-//@[014:016) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource p2_res1child 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:021) Identifier |p2_res1child|
-//@[022:065) StringComplete |'Microsoft.Rp1/resource1/child1@2020-06-01'|
-//@[066:067) Assignment |=|
-//@[068:069) LeftBrace |{|
-//@[069:071) NewLine |\r\n|
   parent: p2_res1
-//@[002:008) Identifier |parent|
-//@[008:009) Colon |:|
-//@[010:017) Identifier |p2_res1|
-//@[017:019) NewLine |\r\n|
   name: 'child1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringComplete |'child1'|
-//@[016:018) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource p2_res2 'Microsoft.Rp2/resource2@2020-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:016) Identifier |p2_res2|
-//@[017:053) StringComplete |'Microsoft.Rp2/resource2@2020-06-01'|
-//@[054:055) Assignment |=|
-//@[056:057) LeftBrace |{|
-//@[057:059) NewLine |\r\n|
   scope: p2_res1child
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:021) Identifier |p2_res1child|
-//@[021:023) NewLine |\r\n|
   name: 'res2'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:014) StringComplete |'res2'|
-//@[014:016) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:021) Identifier |p2_res2child|
-//@[022:065) StringComplete |'Microsoft.Rp2/resource2/child2@2020-06-01'|
-//@[066:067) Assignment |=|
-//@[068:069) LeftBrace |{|
-//@[069:071) NewLine |\r\n|
   parent: p2_res2
-//@[002:008) Identifier |parent|
-//@[008:009) Colon |:|
-//@[010:017) Identifier |p2_res2|
-//@[017:019) NewLine |\r\n|
   name: 'child2'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringComplete |'child2'|
-//@[016:018) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 output p2_res2childprop string = p2_res2child.properties.someProp
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p2_res2childprop|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:045) Identifier |p2_res2child|
-//@[045:046) Dot |.|
-//@[046:056) Identifier |properties|
-//@[056:057) Dot |.|
-//@[057:065) Identifier |someProp|
-//@[065:067) NewLine |\r\n|
 output p2_res2childname string = p2_res2child.name
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p2_res2childname|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:045) Identifier |p2_res2child|
-//@[045:046) Dot |.|
-//@[046:050) Identifier |name|
-//@[050:052) NewLine |\r\n|
 output p2_res2childtype string = p2_res2child.type
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p2_res2childtype|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:045) Identifier |p2_res2child|
-//@[045:046) Dot |.|
-//@[046:050) Identifier |type|
-//@[050:052) NewLine |\r\n|
 output p2_res2childid string = p2_res2child.id
-//@[000:006) Identifier |output|
-//@[007:021) Identifier |p2_res2childid|
-//@[022:028) Identifier |string|
-//@[029:030) Assignment |=|
-//@[031:043) Identifier |p2_res2child|
-//@[043:044) Dot |.|
-//@[044:046) Identifier |id|
-//@[046:050) NewLine |\r\n\r\n|
 
 // parent property with 'existing' resource
-//@[043:045) NewLine |\r\n|
 resource p3_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[000:008) Identifier |resource|
-//@[009:016) Identifier |p3_res1|
-//@[017:053) StringComplete |'Microsoft.Rp1/resource1@2020-06-01'|
-//@[054:062) Identifier |existing|
-//@[063:064) Assignment |=|
-//@[065:066) LeftBrace |{|
-//@[066:068) NewLine |\r\n|
   name: 'res1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:014) StringComplete |'res1'|
-//@[014:016) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource p3_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |p3_child1|
-//@[019:062) StringComplete |'Microsoft.Rp1/resource1/child1@2020-06-01'|
-//@[063:064) Assignment |=|
-//@[065:066) LeftBrace |{|
-//@[066:068) NewLine |\r\n|
   parent: p3_res1
-//@[002:008) Identifier |parent|
-//@[008:009) Colon |:|
-//@[010:017) Identifier |p3_res1|
-//@[017:019) NewLine |\r\n|
   name: 'child1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringComplete |'child1'|
-//@[016:018) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 output p3_res1childprop string = p3_child1.properties.someProp
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p3_res1childprop|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:042) Identifier |p3_child1|
-//@[042:043) Dot |.|
-//@[043:053) Identifier |properties|
-//@[053:054) Dot |.|
-//@[054:062) Identifier |someProp|
-//@[062:064) NewLine |\r\n|
 output p3_res1childname string = p3_child1.name
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p3_res1childname|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:042) Identifier |p3_child1|
-//@[042:043) Dot |.|
-//@[043:047) Identifier |name|
-//@[047:049) NewLine |\r\n|
 output p3_res1childtype string = p3_child1.type
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p3_res1childtype|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:042) Identifier |p3_child1|
-//@[042:043) Dot |.|
-//@[043:047) Identifier |type|
-//@[047:049) NewLine |\r\n|
 output p3_res1childid string = p3_child1.id
-//@[000:006) Identifier |output|
-//@[007:021) Identifier |p3_res1childid|
-//@[022:028) Identifier |string|
-//@[029:030) Assignment |=|
-//@[031:040) Identifier |p3_child1|
-//@[040:041) Dot |.|
-//@[041:043) Identifier |id|
-//@[043:047) NewLine |\r\n\r\n|
 
 // parent & child with 'existing'
-//@[033:035) NewLine |\r\n|
 resource p4_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
-//@[000:008) Identifier |resource|
-//@[009:016) Identifier |p4_res1|
-//@[017:053) StringComplete |'Microsoft.Rp1/resource1@2020-06-01'|
-//@[054:062) Identifier |existing|
-//@[063:064) Assignment |=|
-//@[065:066) LeftBrace |{|
-//@[066:068) NewLine |\r\n|
   scope: tenant()
-//@[002:007) Identifier |scope|
-//@[007:008) Colon |:|
-//@[009:015) Identifier |tenant|
-//@[015:016) LeftParen |(|
-//@[016:017) RightParen |)|
-//@[017:019) NewLine |\r\n|
   name: 'res1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:014) StringComplete |'res1'|
-//@[014:016) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 resource p4_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' existing = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |p4_child1|
-//@[019:062) StringComplete |'Microsoft.Rp1/resource1/child1@2020-06-01'|
-//@[063:071) Identifier |existing|
-//@[072:073) Assignment |=|
-//@[074:075) LeftBrace |{|
-//@[075:077) NewLine |\r\n|
   parent: p4_res1
-//@[002:008) Identifier |parent|
-//@[008:009) Colon |:|
-//@[010:017) Identifier |p4_res1|
-//@[017:019) NewLine |\r\n|
   name: 'child1'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:016) StringComplete |'child1'|
-//@[016:018) NewLine |\r\n|
 }
-//@[000:001) RightBrace |}|
-//@[001:005) NewLine |\r\n\r\n|
 
 output p4_res1childprop string = p4_child1.properties.someProp
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p4_res1childprop|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:042) Identifier |p4_child1|
-//@[042:043) Dot |.|
-//@[043:053) Identifier |properties|
-//@[053:054) Dot |.|
-//@[054:062) Identifier |someProp|
-//@[062:064) NewLine |\r\n|
 output p4_res1childname string = p4_child1.name
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p4_res1childname|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:042) Identifier |p4_child1|
-//@[042:043) Dot |.|
-//@[043:047) Identifier |name|
-//@[047:049) NewLine |\r\n|
 output p4_res1childtype string = p4_child1.type
-//@[000:006) Identifier |output|
-//@[007:023) Identifier |p4_res1childtype|
-//@[024:030) Identifier |string|
-//@[031:032) Assignment |=|
-//@[033:042) Identifier |p4_child1|
-//@[042:043) Dot |.|
-//@[043:047) Identifier |type|
-//@[047:049) NewLine |\r\n|
 output p4_res1childid string = p4_child1.id
-//@[000:006) Identifier |output|
-//@[007:021) Identifier |p4_res1childid|
-//@[022:028) Identifier |string|
-//@[029:030) Assignment |=|
-//@[031:040) Identifier |p4_child1|
-//@[040:041) Dot |.|
-//@[041:043) Identifier |id|
-//@[043:047) NewLine |\r\n\r\n|
 
 // parent & nested child with decorators https://github.com/Azure/bicep/issues/10970
-//@[084:086) NewLine |\r\n|
 var dbs = ['db1', 'db2','db3']
-//@[000:003) Identifier |var|
-//@[004:007) Identifier |dbs|
-//@[008:009) Assignment |=|
-//@[010:011) LeftSquare |[|
-//@[011:016) StringComplete |'db1'|
-//@[016:017) Comma |,|
-//@[018:023) StringComplete |'db2'|
-//@[023:024) Comma |,|
-//@[024:029) StringComplete |'db3'|
-//@[029:030) RightSquare |]|
-//@[030:032) NewLine |\r\n|
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
-//@[000:008) Identifier |resource|
-//@[009:018) Identifier |sqlServer|
-//@[019:053) StringComplete |'Microsoft.Sql/servers@2021-11-01'|
-//@[054:055) Assignment |=|
-//@[056:057) LeftBrace |{|
-//@[057:059) NewLine |\r\n|
   name: 'sql-server-name'
-//@[002:006) Identifier |name|
-//@[006:007) Colon |:|
-//@[008:025) StringComplete |'sql-server-name'|
-//@[025:027) NewLine |\r\n|
   location: 'polandcentral'
-//@[002:010) Identifier |location|
-//@[010:011) Colon |:|
-//@[012:027) StringComplete |'polandcentral'|
-//@[027:031) NewLine |\r\n\r\n|
 
   @batchSize(1)
-//@[002:003) At |@|
-//@[003:012) Identifier |batchSize|
-//@[012:013) LeftParen |(|
-//@[013:014) Integer |1|
-//@[014:015) RightParen |)|
-//@[015:017) NewLine |\r\n|
   @description('Sql Databases')
-//@[002:003) At |@|
-//@[003:014) Identifier |description|
-//@[014:015) LeftParen |(|
-//@[015:030) StringComplete |'Sql Databases'|
-//@[030:031) RightParen |)|
-//@[031:033) NewLine |\r\n|
   resource sqlDatabases 'databases' = [for db in dbs: {
-//@[002:010) Identifier |resource|
-//@[011:023) Identifier |sqlDatabases|
-//@[024:035) StringComplete |'databases'|
-//@[036:037) Assignment |=|
-//@[038:039) LeftSquare |[|
-//@[039:042) Identifier |for|
-//@[043:045) Identifier |db|
-//@[046:048) Identifier |in|
-//@[049:052) Identifier |dbs|
-//@[052:053) Colon |:|
-//@[054:055) LeftBrace |{|
-//@[055:057) NewLine |\r\n|
     name: db
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:012) Identifier |db|
-//@[012:014) NewLine |\r\n|
     location: 'polandcentral'
-//@[004:012) Identifier |location|
-//@[012:013) Colon |:|
-//@[014:029) StringComplete |'polandcentral'|
-//@[029:031) NewLine |\r\n|
   }]
-//@[002:003) RightBrace |}|
-//@[003:004) RightSquare |]|
-//@[004:008) NewLine |\r\n\r\n|
 
   @description('Primary Sql Database')
-//@[002:003) At |@|
-//@[003:014) Identifier |description|
-//@[014:015) LeftParen |(|
-//@[015:037) StringComplete |'Primary Sql Database'|
-//@[037:038) RightParen |)|
-//@[038:040) NewLine |\r\n|
   resource primaryDb 'databases' = {
-//@[002:010) Identifier |resource|
-//@[011:020) Identifier |primaryDb|
-//@[021:032) StringComplete |'databases'|
-//@[033:034) Assignment |=|
-//@[035:036) LeftBrace |{|
-//@[036:038) NewLine |\r\n|
     name: 'primary-db'
-//@[004:008) Identifier |name|
-//@[008:009) Colon |:|
-//@[010:022) StringComplete |'primary-db'|
-//@[022:024) NewLine |\r\n|
     location: 'polandcentral'
 
     resource threatProtection 'advancedThreatProtectionSettings' = {
-//@[004:012) Identifier |location|
-//@[012:013) Colon |:|
-//@[014:029) StringComplete |'polandcentral'|
-//@[029:031) NewLine |\n\n|
       name: 'Default'
       properties: {
-//@[004:012) Identifier |resource|
-//@[013:029) Identifier |threatProtection|
-//@[030:064) StringComplete |'advancedThreatProtectionSettings'|
-//@[065:066) Assignment |=|
-//@[067:068) LeftBrace |{|
-//@[068:070) NewLine |\r\n|
         state: 'Enabled'
-//@[006:010) Identifier |name|
-//@[010:011) Colon |:|
-//@[012:021) StringComplete |'Default'|
-//@[021:023) NewLine |\r\n|
       }
-//@[006:016) Identifier |properties|
-//@[016:017) Colon |:|
-//@[018:019) LeftBrace |{|
-//@[019:021) NewLine |\r\n|
     }
-//@[008:013) Identifier |state|
-//@[013:014) Colon |:|
-//@[015:024) StringComplete |'Enabled'|
-//@[024:026) NewLine |\r\n|
   }
-//@[006:007) RightBrace |}|
-//@[007:009) NewLine |\r\n|
 }
 
 //nameof
 var nameof1 = nameof(sqlServer)
 var nameof2 = nameof(sqlServer.location)
 var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
-//@[004:005) RightBrace |}|
-//@[005:007) NewLine |\r\n|
 var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
-//@[002:003) RightBrace |}|
-//@[003:005) NewLine |\r\n|
 var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
 
 var sqlConfig = {
   westus: {}
-  server: {}
-  'my-rg': {}
-//@[000:001) RightBrace |}|
-//@[001:003) NewLine |\n\n|
+  'server-name': {}
 }
 
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
-  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
-//@[008:009) NewLine |\n|
+  name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
   location: nameof(sqlConfig.westus)
-  scope: resourceGroup(nameof(sqlConfig['my-rg']))
 }
 
-//@[000:003) Identifier |var|
-//@[004:011) Identifier |nameof1|
-//@[012:013) Assignment |=|
-//@[014:020) Identifier |nameof|
-//@[020:021) LeftParen |(|
-//@[021:030) Identifier |sqlServer|
-//@[030:031) RightParen |)|
-//@[031:032) NewLine |\n|
+//@[000:001) NewLine |\n|

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.tokens.bicep
@@ -2566,13 +2566,71 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
 //@[010:022) StringComplete |'primary-db'|
 //@[022:024) NewLine |\r\n|
     location: 'polandcentral'
+
+    resource threatProtection 'advancedThreatProtectionSettings' = {
 //@[004:012) Identifier |location|
 //@[012:013) Colon |:|
 //@[014:029) StringComplete |'polandcentral'|
-//@[029:031) NewLine |\r\n|
+//@[029:031) NewLine |\n\n|
+      name: 'Default'
+      properties: {
+//@[004:012) Identifier |resource|
+//@[013:029) Identifier |threatProtection|
+//@[030:064) StringComplete |'advancedThreatProtectionSettings'|
+//@[065:066) Assignment |=|
+//@[067:068) LeftBrace |{|
+//@[068:070) NewLine |\r\n|
+        state: 'Enabled'
+//@[006:010) Identifier |name|
+//@[010:011) Colon |:|
+//@[012:021) StringComplete |'Default'|
+//@[021:023) NewLine |\r\n|
+      }
+//@[006:016) Identifier |properties|
+//@[016:017) Colon |:|
+//@[018:019) LeftBrace |{|
+//@[019:021) NewLine |\r\n|
+    }
+//@[008:013) Identifier |state|
+//@[013:014) Colon |:|
+//@[015:024) StringComplete |'Enabled'|
+//@[024:026) NewLine |\r\n|
   }
+//@[006:007) RightBrace |}|
+//@[007:009) NewLine |\r\n|
+}
+
+//nameof
+var nameof1 = nameof(sqlServer)
+var nameof2 = nameof(sqlServer.location)
+var nameof3 = nameof(sqlServer::primaryDb.properties.minCapacity)
+//@[004:005) RightBrace |}|
+//@[005:007) NewLine |\r\n|
+var nameof4 = nameof(sqlServer::primaryDb::threatProtection.properties.creationTime)
 //@[002:003) RightBrace |}|
 //@[003:005) NewLine |\r\n|
-}
+var nameof5 = nameof(sqlServer::sqlDatabases[0].id)
+
+var sqlConfig = {
+  westus: {}
+  server: {}
+  'my-rg': {}
 //@[000:001) RightBrace |}|
-//@[001:001) EndOfFile ||
+//@[001:003) NewLine |\n\n|
+}
+
+resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-server-nameof-${nameof(sqlConfig.server)}'
+//@[008:009) NewLine |\n|
+  location: nameof(sqlConfig.westus)
+  scope: resourceGroup(nameof(sqlConfig['my-rg']))
+}
+
+//@[000:003) Identifier |var|
+//@[004:011) Identifier |nameof1|
+//@[012:013) Assignment |=|
+//@[014:020) Identifier |nameof|
+//@[020:021) LeftParen |(|
+//@[021:030) Identifier |sqlServer|
+//@[030:031) RightParen |)|
+//@[031:032) NewLine |\n|

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -2226,6 +2226,27 @@
     }
   },
   {
+    "label": "nameof",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nameof",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "nestedBrackets",
     "kind": "variable",
     "detail": "nestedBrackets",

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -2230,7 +2230,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of the specified parameter, variable, or resource.  \n"
+      "value": "```bicep\nnameof(symbol: any): string\n\n```  \nReturns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2244,6 +2244,48 @@
     "command": {
       "title": "signature help",
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "nameof1",
+    "kind": "variable",
+    "detail": "nameof1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameof1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof1"
+    }
+  },
+  {
+    "label": "nameof2",
+    "kind": "variable",
+    "detail": "nameof2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameof2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof2"
+    }
+  },
+  {
+    "label": "nameof3",
+    "kind": "variable",
+    "detail": "nameof3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nameof3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nameof3"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.bicep
@@ -370,3 +370,8 @@ var test = {
 }
 
 var arraySpread = [...arrayOfBooleans, ...arrayOfHardCodedNumbers, ...arrayOfHardCodedStrings]
+
+
+var nameof1 = nameof(arraySpread)
+var nameof2 = nameof(spread.foo)
+var nameof3 = nameof(myObj.obj.nested)

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.diagnostics.bicep
@@ -56,7 +56,6 @@ var myEmptyArray = [ ]
 // object
 @sys.description('a object variable')
 var myObj = {
-//@[04:09) [no-unused-vars (Warning)] Variable "myObj" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |myObj|
   a: 'a'
   b: -12
   c: true
@@ -459,5 +458,12 @@ var test = {
 }
 
 var arraySpread = [...arrayOfBooleans, ...arrayOfHardCodedNumbers, ...arrayOfHardCodedStrings]
-//@[04:15) [no-unused-vars (Warning)] Variable "arraySpread" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |arraySpread|
+
+
+var nameof1 = nameof(arraySpread)
+//@[04:11) [no-unused-vars (Warning)] Variable "nameof1" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameof1|
+var nameof2 = nameof(spread.foo)
+//@[04:11) [no-unused-vars (Warning)] Variable "nameof2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameof2|
+var nameof3 = nameof(myObj.obj.nested)
+//@[04:11) [no-unused-vars (Warning)] Variable "nameof3" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nameof3|
 

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.formatted.bicep
@@ -381,3 +381,7 @@ var test = {
 }
 
 var arraySpread = [...arrayOfBooleans, ...arrayOfHardCodedNumbers, ...arrayOfHardCodedStrings]
+
+var nameof1 = nameof(arraySpread)
+var nameof2 = nameof(spread.foo)
+var nameof3 = nameof(myObj.obj.nested)

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.ir.bicep
@@ -1,5 +1,5 @@
 
-//@[000:8106) ProgramExpression
+//@[000:8214) ProgramExpression
 // int
 @sys.description('an int variable')
 //@[000:0050) ├─DeclaredVariableExpression { Name = myInt }
@@ -1111,10 +1111,21 @@ var test = {
 }
 
 var arraySpread = [...arrayOfBooleans, ...arrayOfHardCodedNumbers, ...arrayOfHardCodedStrings]
-//@[000:0094) └─DeclaredVariableExpression { Name = arraySpread }
-//@[018:0094)   └─FunctionCallExpression { Name = flatten }
-//@[018:0094)     └─ArrayExpression
-//@[022:0037)       ├─VariableReferenceExpression { Variable = arrayOfBooleans }
-//@[042:0065)       ├─VariableReferenceExpression { Variable = arrayOfHardCodedNumbers }
-//@[070:0093)       └─VariableReferenceExpression { Variable = arrayOfHardCodedStrings }
+//@[000:0094) ├─DeclaredVariableExpression { Name = arraySpread }
+//@[018:0094) | └─FunctionCallExpression { Name = flatten }
+//@[018:0094) |   └─ArrayExpression
+//@[022:0037) |     ├─VariableReferenceExpression { Variable = arrayOfBooleans }
+//@[042:0065) |     ├─VariableReferenceExpression { Variable = arrayOfHardCodedNumbers }
+//@[070:0093) |     └─VariableReferenceExpression { Variable = arrayOfHardCodedStrings }
+
+
+var nameof1 = nameof(arraySpread)
+//@[000:0033) ├─DeclaredVariableExpression { Name = nameof1 }
+//@[021:0032) | └─StringLiteralExpression { Value = arraySpread }
+var nameof2 = nameof(spread.foo)
+//@[000:0032) ├─DeclaredVariableExpression { Name = nameof2 }
+//@[021:0031) | └─StringLiteralExpression { Value = foo }
+var nameof3 = nameof(myObj.obj.nested)
+//@[000:0038) └─DeclaredVariableExpression { Name = nameof3 }
+//@[021:0037)   └─StringLiteralExpression { Value = nested }
 

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3772439174458986220"
+      "templateHash": "12058230623899485737"
     }
   },
   "parameters": {
@@ -288,7 +288,10 @@
     "isPrefixed": "[startsWith('food', 'foo')]",
     "spread": "[shallowMerge(createArray(createObject('foo', 'abc'), variables('issue1332')))]",
     "test": "[shallowMerge(createArray(variables('spread'), createObject('bar', 'def')))]",
-    "arraySpread": "[flatten(createArray(variables('arrayOfBooleans'), variables('arrayOfHardCodedNumbers'), variables('arrayOfHardCodedStrings')))]"
+    "arraySpread": "[flatten(createArray(variables('arrayOfBooleans'), variables('arrayOfHardCodedNumbers'), variables('arrayOfHardCodedStrings')))]",
+    "nameof1": "arraySpread",
+    "nameof2": "foo",
+    "nameof3": "nested"
   },
   "resources": []
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.sourcemap.bicep
@@ -645,5 +645,13 @@ var test = {
 }
 
 var arraySpread = [...arrayOfBooleans, ...arrayOfHardCodedNumbers, ...arrayOfHardCodedStrings]
-//@    "arraySpread": "[flatten(createArray(variables('arrayOfBooleans'), variables('arrayOfHardCodedNumbers'), variables('arrayOfHardCodedStrings')))]"
+//@    "arraySpread": "[flatten(createArray(variables('arrayOfBooleans'), variables('arrayOfHardCodedNumbers'), variables('arrayOfHardCodedStrings')))]",
+
+
+var nameof1 = nameof(arraySpread)
+//@    "nameof1": "arraySpread",
+var nameof2 = nameof(spread.foo)
+//@    "nameof2": "foo",
+var nameof3 = nameof(myObj.obj.nested)
+//@    "nameof3": "nested"
 

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4260162552164475821"
+      "templateHash": "12582540616709243429"
     }
   },
   "parameters": {
@@ -289,7 +289,10 @@
     "isPrefixed": "[startsWith('food', 'foo')]",
     "spread": "[shallowMerge(createArray(createObject('foo', 'abc'), variables('issue1332')))]",
     "test": "[shallowMerge(createArray(variables('spread'), createObject('bar', 'def')))]",
-    "arraySpread": "[flatten(createArray(variables('arrayOfBooleans'), variables('arrayOfHardCodedNumbers'), variables('arrayOfHardCodedStrings')))]"
+    "arraySpread": "[flatten(createArray(variables('arrayOfBooleans'), variables('arrayOfHardCodedNumbers'), variables('arrayOfHardCodedStrings')))]",
+    "nameof1": "arraySpread",
+    "nameof2": "foo",
+    "nameof3": "nested"
   },
   "resources": {}
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.symbols.bicep
@@ -508,3 +508,11 @@ var test = {
 var arraySpread = [...arrayOfBooleans, ...arrayOfHardCodedNumbers, ...arrayOfHardCodedStrings]
 //@[04:15) Variable arraySpread. Type: ('hi' | 3 | bool)[]. Declaration start char: 0, length: 94
 
+
+var nameof1 = nameof(arraySpread)
+//@[04:11) Variable nameof1. Type: 'arraySpread'. Declaration start char: 0, length: 33
+var nameof2 = nameof(spread.foo)
+//@[04:11) Variable nameof2. Type: 'foo'. Declaration start char: 0, length: 32
+var nameof3 = nameof(myObj.obj.nested)
+//@[04:11) Variable nameof3. Type: 'nested'. Declaration start char: 0, length: 38
+

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[000:8106) ProgramSyntax
+//@[000:8214) ProgramSyntax
 //@[000:0001) ├─Token(NewLine) |\n|
 // int
 //@[006:0007) ├─Token(NewLine) |\n|
@@ -3251,6 +3251,68 @@ var arraySpread = [...arrayOfBooleans, ...arrayOfHardCodedNumbers, ...arrayOfHar
 //@[070:0093) |   |   └─IdentifierSyntax
 //@[070:0093) |   |     └─Token(Identifier) |arrayOfHardCodedStrings|
 //@[093:0094) |   └─Token(RightSquare) |]|
-//@[094:0095) ├─Token(NewLine) |\n|
+//@[094:0097) ├─Token(NewLine) |\n\n\n|
+
+
+var nameof1 = nameof(arraySpread)
+//@[000:0033) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0011) | ├─IdentifierSyntax
+//@[004:0011) | | └─Token(Identifier) |nameof1|
+//@[012:0013) | ├─Token(Assignment) |=|
+//@[014:0033) | └─FunctionCallSyntax
+//@[014:0020) |   ├─IdentifierSyntax
+//@[014:0020) |   | └─Token(Identifier) |nameof|
+//@[020:0021) |   ├─Token(LeftParen) |(|
+//@[021:0032) |   ├─FunctionArgumentSyntax
+//@[021:0032) |   | └─VariableAccessSyntax
+//@[021:0032) |   |   └─IdentifierSyntax
+//@[021:0032) |   |     └─Token(Identifier) |arraySpread|
+//@[032:0033) |   └─Token(RightParen) |)|
+//@[033:0034) ├─Token(NewLine) |\n|
+var nameof2 = nameof(spread.foo)
+//@[000:0032) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0011) | ├─IdentifierSyntax
+//@[004:0011) | | └─Token(Identifier) |nameof2|
+//@[012:0013) | ├─Token(Assignment) |=|
+//@[014:0032) | └─FunctionCallSyntax
+//@[014:0020) |   ├─IdentifierSyntax
+//@[014:0020) |   | └─Token(Identifier) |nameof|
+//@[020:0021) |   ├─Token(LeftParen) |(|
+//@[021:0031) |   ├─FunctionArgumentSyntax
+//@[021:0031) |   | └─PropertyAccessSyntax
+//@[021:0027) |   |   ├─VariableAccessSyntax
+//@[021:0027) |   |   | └─IdentifierSyntax
+//@[021:0027) |   |   |   └─Token(Identifier) |spread|
+//@[027:0028) |   |   ├─Token(Dot) |.|
+//@[028:0031) |   |   └─IdentifierSyntax
+//@[028:0031) |   |     └─Token(Identifier) |foo|
+//@[031:0032) |   └─Token(RightParen) |)|
+//@[032:0033) ├─Token(NewLine) |\n|
+var nameof3 = nameof(myObj.obj.nested)
+//@[000:0038) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0011) | ├─IdentifierSyntax
+//@[004:0011) | | └─Token(Identifier) |nameof3|
+//@[012:0013) | ├─Token(Assignment) |=|
+//@[014:0038) | └─FunctionCallSyntax
+//@[014:0020) |   ├─IdentifierSyntax
+//@[014:0020) |   | └─Token(Identifier) |nameof|
+//@[020:0021) |   ├─Token(LeftParen) |(|
+//@[021:0037) |   ├─FunctionArgumentSyntax
+//@[021:0037) |   | └─PropertyAccessSyntax
+//@[021:0030) |   |   ├─PropertyAccessSyntax
+//@[021:0026) |   |   | ├─VariableAccessSyntax
+//@[021:0026) |   |   | | └─IdentifierSyntax
+//@[021:0026) |   |   | |   └─Token(Identifier) |myObj|
+//@[026:0027) |   |   | ├─Token(Dot) |.|
+//@[027:0030) |   |   | └─IdentifierSyntax
+//@[027:0030) |   |   |   └─Token(Identifier) |obj|
+//@[030:0031) |   |   ├─Token(Dot) |.|
+//@[031:0037) |   |   └─IdentifierSyntax
+//@[031:0037) |   |     └─Token(Identifier) |nested|
+//@[037:0038) |   └─Token(RightParen) |)|
+//@[038:0039) ├─Token(NewLine) |\n|
 
 //@[000:0000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.tokens.bicep
@@ -2046,6 +2046,41 @@ var arraySpread = [...arrayOfBooleans, ...arrayOfHardCodedNumbers, ...arrayOfHar
 //@[067:070) Ellipsis |...|
 //@[070:093) Identifier |arrayOfHardCodedStrings|
 //@[093:094) RightSquare |]|
-//@[094:095) NewLine |\n|
+//@[094:097) NewLine |\n\n\n|
+
+
+var nameof1 = nameof(arraySpread)
+//@[000:003) Identifier |var|
+//@[004:011) Identifier |nameof1|
+//@[012:013) Assignment |=|
+//@[014:020) Identifier |nameof|
+//@[020:021) LeftParen |(|
+//@[021:032) Identifier |arraySpread|
+//@[032:033) RightParen |)|
+//@[033:034) NewLine |\n|
+var nameof2 = nameof(spread.foo)
+//@[000:003) Identifier |var|
+//@[004:011) Identifier |nameof2|
+//@[012:013) Assignment |=|
+//@[014:020) Identifier |nameof|
+//@[020:021) LeftParen |(|
+//@[021:027) Identifier |spread|
+//@[027:028) Dot |.|
+//@[028:031) Identifier |foo|
+//@[031:032) RightParen |)|
+//@[032:033) NewLine |\n|
+var nameof3 = nameof(myObj.obj.nested)
+//@[000:003) Identifier |var|
+//@[004:011) Identifier |nameof3|
+//@[012:013) Assignment |=|
+//@[014:020) Identifier |nameof|
+//@[020:021) LeftParen |(|
+//@[021:026) Identifier |myObj|
+//@[026:027) Dot |.|
+//@[027:030) Identifier |obj|
+//@[030:031) Dot |.|
+//@[031:037) Identifier |nested|
+//@[037:038) RightParen |)|
+//@[038:039) NewLine |\n|
 
 //@[000:000) EndOfFile ||

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -2211,6 +2211,11 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP406",
                 $"The \"{LanguageConstants.ExtendsKeyword}\" keyword is not supported");
+
+            public ErrorDiagnostic ExpressionDoesNotHaveAName() => new(
+                TextSpan,
+                "BCP407",
+                $"Expression does not have a name");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -110,6 +110,11 @@ namespace Bicep.Core.Emit
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
             VisitFunctionCallSyntaxBaseInternal(syntax);
+            if (string.Equals(syntax.Name.IdentifierName, LanguageConstants.NameofFunctionName, StringComparison.Ordinal))
+            {
+                // anything within nameof function will never be inlined, so we can skip checking deeper
+                return;
+            }
             base.VisitFunctionCallSyntax(syntax);
         }
 

--- a/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
@@ -16,6 +16,7 @@ namespace Bicep.Core.Emit
         private Options? options;
         private readonly IDictionary<DeclaredSymbol, HashSet<ResourceDependency>> resourceDependencies;
         private DeclaredSymbol? currentDeclaration;
+        private bool insideNameofFunction;
 
 
         public struct Options
@@ -154,7 +155,7 @@ namespace Bicep.Core.Emit
 
         public override void VisitVariableAccessSyntax(VariableAccessSyntax syntax)
         {
-            if (currentDeclaration is null)
+            if (currentDeclaration is null || insideNameofFunction)
             {
                 return;
             }
@@ -193,7 +194,7 @@ namespace Bicep.Core.Emit
 
         public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
         {
-            if (currentDeclaration is null)
+            if (currentDeclaration is null || insideNameofFunction)
             {
                 return;
             }
@@ -280,6 +281,13 @@ namespace Bicep.Core.Emit
             }
 
             base.VisitObjectPropertySyntax(propertySyntax);
+        }
+
+        public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
+        {
+            insideNameofFunction = syntax.Name.IdentifierName == LanguageConstants.NameofFunctionName;
+            base.VisitFunctionCallSyntax(syntax);
+            insideNameofFunction = false;
         }
 
         private bool IsTopLevelPropertyOfCurrentDeclaration(ObjectPropertySyntax propertySyntax)

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -196,6 +196,8 @@ namespace Bicep.Core
         public const string StringHoleClose = "}";
 
         public const string AnyFunction = "any";
+        public const string NameofFunctionName = "nameof";
+
         public static readonly TypeSymbol Any = new AnyType();
         public static readonly TypeSymbol Never = new UnionType("never", []);
 

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1065,6 +1065,7 @@ namespace Bicep.Core.Semantics.Namespaces
                             PropertyAccessSyntax propertyAccess => propertyAccess.PropertyName.IdentifierName,
                             ResourceAccessSyntax resourceAccess => resourceAccess.ResourceName.IdentifierName,
                             ModuleDeclarationSyntax moduleDeclaration => moduleDeclaration.Name.IdentifierName,
+                            ArrayAccessSyntax arrayAccess => arrayAccess.IndexExpression.ToString(),
                             _ => null,
                         };
                         if (x is null)
@@ -1081,6 +1082,7 @@ namespace Bicep.Core.Semantics.Namespaces
                             PropertyAccessSyntax propertyAccess => propertyAccess.PropertyName.IdentifierName,
                             ResourceAccessSyntax resourceAccess => resourceAccess.ResourceName.IdentifierName,
                             ModuleDeclarationSyntax moduleDeclaration => moduleDeclaration.Name.IdentifierName,
+                            ArrayAccessSyntax arrayAccess => arrayAccess.IndexExpression.ToString(),
                             _ => string.Empty,
                         };
                         return new StringLiteralExpression(expression.Parameters[0].SourceSyntax, x);

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1055,8 +1055,8 @@ namespace Bicep.Core.Semantics.Namespaces
                     .Build();
 
                 yield return new FunctionOverloadBuilder(LanguageConstants.NameofFunctionName)
-                    .WithGenericDescription("Returns the name of the specified parameter, variable, or resource.")
-                    .WithRequiredParameter("symbol", LanguageConstants.Any, "The parameter, variable, or resource to retrieve the name of.")
+                    .WithGenericDescription("Returns the name of a variable, resource, module or property as the string constant. Function is evaluated at compile time and has no effect during deployment.")
+                    .WithRequiredParameter("symbol", LanguageConstants.Any, "The variable, resource, module or property to produce the name.")
                     .WithReturnResultBuilder((model, diagnostics, call, argumentTypes) =>
                     {
                         var x = call.Arguments[0].Expression switch
@@ -1069,7 +1069,7 @@ namespace Bicep.Core.Semantics.Namespaces
                         };
                         if (x is null)
                         {
-                            return new(ErrorType.Create(DiagnosticBuilder.ForPosition(call.Arguments[0]).CompileTimeConstantRequired()));
+                            return new(ErrorType.Create(DiagnosticBuilder.ForPosition(call.Arguments[0]).ExpressionDoesNotHaveAName()));
                         }
                         return new(new StringLiteralType(x, TypeSymbolValidationFlags.Default));
                     }, LanguageConstants.String)

--- a/src/Bicep.Core/Syntax/AstVisitor.cs
+++ b/src/Bicep.Core/Syntax/AstVisitor.cs
@@ -293,6 +293,7 @@ namespace Bicep.Core.Syntax
 
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
+
             this.Visit(syntax.Name);
             this.VisitNodes(syntax.Children);
         }

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantDirectViolationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantDirectViolationVisitor.cs
@@ -74,7 +74,6 @@ namespace Bicep.Core.TypeSystem
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
             this.FlagIfFunctionRequiresInlining(syntax);
-
             base.VisitFunctionCallSyntax(syntax);
         }
 

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantViolationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantViolationVisitor.cs
@@ -33,8 +33,14 @@ namespace Bicep.Core.TypeSystem
 
         protected ResourceTypeResolver ResourceTypeResolver { get; }
 
+        private bool insideNameofFunction;
+
         protected void FlagDeployTimeConstantViolation(SyntaxBase errorSyntax, DeclaredSymbol? accessedSymbol = null, ObjectType? accessedObjectType = null, IEnumerable<string>? variableDependencyChain = null, string? violatingPropertyName = null)
         {
+            if (insideNameofFunction)
+            {
+                return;
+            }
             var accessedSymbolName = accessedSymbol?.Name;
             var accessiblePropertyNames = GetAccessiblePropertyNames(accessedSymbol, accessedObjectType);
 
@@ -94,6 +100,13 @@ namespace Bicep.Core.TypeSystem
             }
 
             return accessiblePropertyNames;
+        }
+
+        public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
+        {
+            insideNameofFunction = syntax.Name.IdentifierName == LanguageConstants.NameofFunctionName;
+            base.VisitFunctionCallSyntax(syntax);
+            insideNameofFunction = false;
         }
     }
 }


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
